### PR TITLE
removed skos.ttl

### DIFF
--- a/Models/common/skos.ttl
+++ b/Models/common/skos.ttl
@@ -1,3 +1,0 @@
-#for skos concepts
-# TODO
-# has to be TTL format


### PR DESCRIPTION
skos concepts are defined in begrip.ttl, so this file is redundant.