### PR TITLE
Clean common

### DIFF
--- a/Models/Specific/Bestemmingsplan/shapes.ttl
+++ b/Models/Specific/Bestemmingsplan/shapes.ttl
@@ -111,18 +111,18 @@ ro_str:Bestemmingsplan_externPlan a sh:PropertyShape ;
   sh:node ro_str:ExternPlanReferentie_BP ;
 .
 
-#TODO: Test if this works
-ro_str:ExternPlanReferentie_BP rdf:type sh:NodeShape ;
-  sh:closed true ;
-  sh:ignoredProperties (
-    ro:muteert
-    ro:vervangt
-    ro:tenGevolgeVan
-    ) ;
-.
+
+#ro_str:ExternPlanReferentie_BP rdf:type sh:NodeShape ;
+#  sh:closed true ;
+#  sh:ignoredProperties (
+#    ro:muteert
+#    ro:vervangt
+#    ro:tenGevolgeVan
+#    ) ;
+#.
 
 ro_str:Bestemmingsplan_norm a sh:PropertyShape ;
-  sh:path ro:verwijzingNorm ;
+  sh:path ro:norm ;
   sh:minCount 2 ;
   sh:maxCount 4 ;
   sh:and ( [

--- a/Models/Specific/Structuurvisie/Structuurvisie_P/shapes.ttl
+++ b/Models/Specific/Structuurvisie/Structuurvisie_P/shapes.ttl
@@ -226,7 +226,7 @@ ro_str:Structuurvisieverklaring_illustratieverwijzing a sh:PropertyShape ;
   sh:path ro:illustratie ;
   sh:class ro:Illustratie ;
   sh:node
-    ro_str:Illustratie ,
+#    ro_str:Illustratie ,
     ro_str:Illustratie_legendaNaam ,
     ro_str:Illustratie_illustratieNaam
 .

--- a/Models/Specific/Structuurvisie/shapes.ttl
+++ b/Models/Specific/Structuurvisie/shapes.ttl
@@ -151,7 +151,7 @@ ro_str:Structuurvisiegebied_thema a sh:PropertyShape ;
 ro_str:Structuurvisiegebied_illustratieVerwijzing a sh:PropertyShape ;
   sh:path ro:illustratie ;
   sh:class ro:Illustratie ;
-  sh:node ro_str:Illustratie ;
+#  sh:node ro_str:Illustratie ;
   sh:node ro_str:Illustratie_legendaNaam
 .
 

--- a/Models/common/Overheid/model.ttl
+++ b/Models/common/Overheid/model.ttl
@@ -20,57 +20,50 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-ro:Overheid
-  rdf:type owl:Class ;
+#################################################################
+#    Overheid
+#################################################################
+
+
+ro:Overheid a owl:Class ;
   rdfs:label "Overheden"@nl ;
 .
 
-ro:NationaleOverheid
-  rdf:type owl:Class ;
+ro:NationaleOverheid a owl:Class ;
   rdfs:label "nationale overheid"@nl ;
   rdfs:subClassOf ro:Overheid ;
 .
 
-ro:ProvincialeOverheid
-  rdf:type owl:Class ;
+ro:ProvincialeOverheid a owl:Class ;
   rdfs:label "provinciale overheid"@nl ;
   rdfs:subClassOf ro:Overheid ;
 .
 
-ro:GemeentelijkeOverheid
-  rdf:type owl:Class ;
+ro:GemeentelijkeOverheid a owl:Class ;
   rdfs:label "gemeentelijke overheid"@nl ;
   rdfs:subClassOf ro:Overheid ;
 .
 
-ro:Deelgemeente_Stadsdeel
-  rdf:type owl:Class ;
+ro:Deelgemeente_Stadsdeel a owl:Class ;
   rdfs:label "Deelgemeente/Stadsdeel"@nl ;
   rdfs:subClassOf ro:Overheid ;
 .
 
-ro:beleidsmatigVerantwoordelijkeOverheid
-  rdf:type owl:ObjectProperty ;
+ro:beleidsmatigVerantwoordelijkeOverheid a owl:ObjectProperty ;
   rdfs:domain nen3610:Plangebied ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "beleidsmatigerantwoordelijke overheid"@nl ;
   rdfs:range ro:Overheid ;
 .
 
-ro:naamOverheid # use ro:naam?
-  rdf:type owl:AnnotationProperty ;
+ro:naamOverheid a owl:AnnotationProperty ;
   rdfs:domain ro:Overheid ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "naam overheid"@nl ;
 .
-# TODO: change to ro:code, not to forget the SHACL shapes.
-ro:overheidsCode
-  rdf:type owl:AnnotationProperty ;
+
+ro:overheidsCode a owl:AnnotationProperty ;
   rdfs:domain ro:Overheid ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "overheids code"@nl ;
 .
-#ro:code a owl:DatatypeProperty ;
-#  rdfs:label "code"@nl ;
-#  rdfs:isDefinedBy :ro
-#.

--- a/Models/common/Overheid/shapes.ttl
+++ b/Models/common/Overheid/shapes.ttl
@@ -17,7 +17,7 @@ ro_str:Overheid a sh:NodeShape ;
   sh:targetClass ro:Overheid ;
   sh:Property
     ro_str:overheidsNaam ,
-    ro_str:overheidsCode ;
+    ro_str:overheidsCode
 .
 
 ro_str:overheidsNaam a sh:PropertyShape ;
@@ -45,12 +45,10 @@ ro_str:Overheden_R a sh:NodeShape ;
   sh:property [
     sh:path ro:overheidsCode ;
     sh:hasValue "0000" ; # would the use of sh:pattern be preffered for consistency's sake?
-#    sh:datatype xsd:string ;  # see next property
   ] ;
   sh:property [
     sh:path ro:overheidsNaam ;
     sh:pattern "^(ministerie)\\s" ;
-#    sh:datatype xsd:string ; # already specified in ro_str:overheidsNaam
     ]
 .
 
@@ -83,5 +81,5 @@ ro_str:Overheden_G a sh:NodeShape ;
       sh:pattern "^(gemeente)\\s" ; ]
     [
       sh:pattern "^(deelgemeente/stadsdeel)\\s" ; ]
-    ) ] ;
+    ) ] 
 .

--- a/Models/common/begrip.ttl
+++ b/Models/common/begrip.ttl
@@ -1559,3 +1559,14 @@ ro_beg:voorbereidingsbesluit a skos:Concept ;
   skos-thes:broaderGeneric ro_beg:Instrument
   skos:inScheme ro_begkr:ro
 .
+
+#################################################################
+#  Rol extern Plan TODO
+#################################################################
+
+ro_beg:muteert a skos:Concept .
+ro_beg:vervang a skos:Concept .
+ro_beg:uitTeWerkenIn a skos:Concept .
+ro_beg:uitgewerktIn a skos:Concept .
+ro_beg:gebruiktInformatieUit a skos:Concept .
+ro_beg:tenGevolgeVan a skos:Concept .

--- a/Models/common/begrip.ttl
+++ b/Models/common/begrip.ttl
@@ -1568,5 +1568,7 @@ ro_beg:muteert a skos:Concept .
 ro_beg:vervang a skos:Concept .
 ro_beg:uitTeWerkenIn a skos:Concept .
 ro_beg:uitgewerktIn a skos:Concept .
-ro_beg:gebruiktInformatieUit a skos:Concept .
+ro_beg:gebruiktInformatieUit a skos:Concept ;
+  skos:notation "informatie in extern plan/besluit" .
+  
 ro_beg:tenGevolgeVan a skos:Concept .

--- a/Models/common/begrip.ttl
+++ b/Models/common/begrip.ttl
@@ -14,7 +14,13 @@
 #    Plan
 #################################################################
 
- #TODO
+ro_beg:Plan a skos:Concept ;
+  rdfs:label "Plan"@nl ;
+  skos:prefLabel "Plan"@nl ;
+  skos:inScheme ro_begkr:ro ;
+  skos:definition "TODO"@nl ;
+  skos:scopeNote "TODO"@nl
+.
 
  ro_beg:Plangebied a skos:Concept ;
    rdfs:label "Plangebied"@nl ;
@@ -1407,4 +1413,149 @@ ro_beg:PRpSV2012 a skos:Concept ; #new from structuurvisieplangebied_P.
   skos:prefLabel "PRpSV2012"@nl ;
   skos-thes:broaderGeneric ro_beg:Norm ;
   skos:notation "PRpSV2012"
+.
+
+#################################################################
+#  Ondergronden
+#################################################################
+
+
+ro_beg:Ondergrond a skos:Concept ;
+  rdfs:label "Grootschalige basiskaart"@nl ;
+  skos:prefLabel "Grootschalige basiskaart"@nl ;
+  skos:altLabel "GBK"@nl ;
+  skos-thes:broaderGeneric ro_beg:Ondergrond ;
+  skos:topConceptOf ro_begkr:ro ;
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:GrootschaligeBasiskaart a skos:Concept ;
+  rdfs:label "Grootschalige basiskaart"@nl ;
+  skos:prefLabel "Grootschalige basiskaart"@nl ;
+  skos:altLabel "GBK"@nl ;
+  skos-thes:broaderGeneric ro_beg:Ondergrond ;
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:BasisregistratieGrootschaligeTopografie a skos:Concept ;
+  rdfs:label "Basisregistratie grootschalige topografie"@nl ;
+  skos:prefLabel "Basisregistratie grootschalige topografie"@nl ;
+  skos:altLabel "BGT"@nl ;
+  skos-thes:broaderGeneric ro_beg:Ondergrond ;
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:BasisregistratieTopografie a skos:Concept ;
+  rdfs:label "Basisregistratie topografie"@nl ;
+  skos:prefLabel "Basisregistratie topografie"@nl ;
+  skos:altLabel "BRT"@nl ;
+  skos-thes:broaderGeneric ro_beg:Ondergrond ;
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:BasisregistratieKadaster a skos:Concept ;
+  rdfs:label "Basisregistratie kadaster"@nl ;
+  skos:prefLabel "Basisregistratie kadaster"@nl ;
+  skos:altLabel "BRK"@nl ;
+  skos-thes:broaderGeneric ro_beg:Ondergrond ;
+  skos:inScheme ro_begkr:ro
+.
+
+
+#################################################################
+#  Instrumenten
+#################################################################
+
+
+ro_beg:Instrument a skos:Concept ;
+  rdfs:label "Instrument"@nl ;
+  skos:prefLabel "Instrument"@nl ;
+  skos:topConceptOf ro_begkr:ro ;
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:amvb a skos:Concept ;
+  rdfs:label "amvb"@nl ;
+  skos:prefLabel "amvb"@nl ;
+  skos:altLabel "Algemene Maatregel van Bestuur"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:beheersverordening a skos:Concept ;
+  rdfs:label "beheersverordening"@nl ;
+  skos:prefLabel "beheersverordening"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:bestuurlijkeAfspraken a skos:Concept ;
+  rdfs:label "bestuurlijke afspraken"@nl ;
+  skos:prefLabel "bestuurlijke afspraken"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:coordinatieregeling a skos:Concept ;
+  rdfs:label "coordinatie regeling"@nl ;
+  skos:prefLabel "coordinatie regeling"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:inpassingsplan a skos:Concept ;
+  rdfs:label "inpassingsplan"@nl ;
+  skos:prefLabel "inpassingsplan"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument ;
+  skos:notation "IMRO2012"
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:omgevingsvergunning a skos:Concept ;
+  rdfs:label "omgevingsvergunning"@nl ;
+  skos:prefLabel "omgevingsvergunning"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:proactieveAanwijzing a skos:Concept ;
+  rdfs:label "proactieve aanwijzing"@nl ;
+  skos:prefLabel "proactieve aanwijzing"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:reactieveAanwijzing a skos:Concept ;
+  rdfs:label "reactieve aanwijzing"@nl ;
+  skos:prefLabel "reactieve aanwijzing"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:vooroverleg a skos:Concept ;
+  rdfs:label "vooroverleg"@nl ;
+  skos:prefLabel "vooroverleg"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:zienswijze a skos:Concept ;
+  rdfs:label "zienswijze"@nl ;
+  skos:prefLabel "zienswijze"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:verordening a skos:Concept ;
+  rdfs:label "verordening"@nl ;
+  skos:prefLabel "verordening"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
+.
+
+ro_beg:voorbereidingsbesluit a skos:Concept ;
+  rdfs:label "voorbereidingsbesluit"@nl ;
+  skos:prefLabel "voorbereidingsbesluit"@nl ;
+  skos-thes:broaderGeneric ro_beg:Instrument
+  skos:inScheme ro_begkr:ro
 .

--- a/Models/common/geometrie/model.ttl
+++ b/Models/common/geometrie/model.ttl
@@ -20,36 +20,31 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-ro:Geometrie
-  rdf:type owl:Class ;
+ro:Geometrie a owl:Class ;
   rdfs:subClassOf ogc:Geometry ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "Geometrie"@nl ;
 .
 
-ro:geometrie
-  rdf:type owl:ObjectProperty ;
+ro:geometrie a owl:ObjectProperty ;
   rdfs:subPropertyOf ogc:hasGeometry ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "geometrie"@nl ;
 .
 
-ro:idealisatie
-  rdf:type owl:ObjectProperty ;
+ro:idealisatie a owl:ObjectProperty ;
   rdfs:domain ro:Geometrie ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "idealisatie"@nl ;
 .
 
-ro:begrenzing
-  rdf:type owl:ObjectProperty ;
+ro:begrenzing a owl:ObjectProperty ;
   rdfs:subPropertyOf ogc:hasGeometry ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "begrenzing"@nl ;
 .
 
-ro:inwinningsschaal
-  rdf:type owl:DatatypeProperty ;
+ro:inwinningsschaal a owl:DatatypeProperty ;
   rdfs:domain ro:Geometrie ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "inwinningsschaal"@nl ;

--- a/Models/common/geometrie/shapes.ttl
+++ b/Models/common/geometrie/shapes.ttl
@@ -15,24 +15,20 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 
-# include a shape for geometrie?  all is now in the specific shapes. Can probably extract some common parts.
-
-#not really used..
-
-ro_str:Idealisatie_1 rdf:type sh:NodeShape ;
+ro_str:Idealisatie_1 a sh:NodeShape ;
   sh:in (
     ro_beg:exact
   )
 .
 
-ro_str:Idealisatie_2 rdf:type sh:NodeShape ;
+ro_str:Idealisatie_2 a sh:NodeShape ;
   sh:in (
     ro_beg:exact
     ro_beg:indicatief
   )
 .
 
-ro_str:Idealisatie_3 rdf:type sh:NodeShape ;
+ro_str:Idealisatie_3 a sh:NodeShape ;
   sh:in (
     ro_beg:exact
     ro_beg:indicatief

--- a/Models/common/model.ttl
+++ b/Models/common/model.ttl
@@ -48,7 +48,7 @@ ro:Plangebied a owl:Class ;
   rdfs:subClassOf nen3610:PlanologischGebied
 .
 
-ro:Planobject a owl:Class
+ro:Planobject a owl:Class ;
   rdfs:label "Planobject"@nl ;
   rdfs:isDefinedBy :ro ;
   rdfs:comment "Ruimtelijk object welke zich bevindt in een bijbehorend plangebied."@nl ;
@@ -98,31 +98,36 @@ ro:thema a owl:DatatypeProperty ;             #is this a datatype/annotation or 
 ro:Ondergrond a owl:Class ;
   rdfs:label "Ondergrond"@nl ;
   rdfs:isDefinedBy :ro ;
+  dcterms:subject ro_beg:Ondergrond ;
   rdfs:comment "naamgeving van de gebruikte ondergrond bij het instrument."@nl
 .
 
-ro:GrootschaligeBasiskaart a owl:Class ; #(GBK)
+ro:GrootschaligeBasiskaart a owl:Class ;
   rdfs:subClassOf ro:Ondergrond ;
   rdfs:isDefinedBy :ro ;
+  dcterms:subject ro_beg:GrootschaligeBasiskaart ;
   rdfs:label "Grootschalige basiskaart"@nl
 .
 
-ro:BasisregistratieGrootschaligeTopografie a owl:Class ; #(BGT)
+ro:BasisregistratieGrootschaligeTopografie a owl:Class ;
   rdfs:subClassOf ro:Ondergrond ;
   rdfs:isDefinedBy :ro ;
+  dcterms:subject ro_beg:BasisregistratieGrootschaligeTopografie ;
   rdfs:label "Basisregistratie grootschalige topografie"@nl
 .
 
-ro:BasisregistratieTopografie a owl:Class ; #(BRT)
+ro:BasisregistratieTopografie a owl:Class ;
   rdfs:subClassOf ro:Ondergrond ;
   rdfs:isDefinedBy :ro ;
+  dcterms:subject ro_beg:BasisregistratieTopografie ;
   rdfs:label "Basisregistratie topografie"@nl
 .
 
-ro:BasisregistratieKadaster a owl:Class ; #(BRK)
+ro:BasisregistratieKadaster a owl:Class ;
   rdfs:subClassOf ro:Ondergrond ;
   rdfs:isDefinedBy :ro ;
-  rdfs:label "Basisregistratie kadaster"@nl
+  rdfs:label "Basisregistratie kadaster"@nl ;
+  dcterms:subject ro_beg:BasisregistratieKadaster
 .
 
 ro:ondergrond a owl:ObjectProperty ;
@@ -155,4 +160,11 @@ ro:belang a owl:DatatypeProperty ;
 ro:rol a owl:DatatypeProperty ;
   rdfs:label "rol"@nl ;
   rdfs:isDefinedBy :ro
+.
+
+ro:instrument
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:label "instrument"@nl ;
+  rdfs:range ro_beg:Instrument ;
 .

--- a/Models/common/model.ttl
+++ b/Models/common/model.ttl
@@ -21,7 +21,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :ro
-  rdf:type owl:Ontology ;
+  a owl:Ontology ;
   dc:description "TODO"@nl ;
   dc:title "Ruimtelijke Ordening vocabulaire"@nl ;
   rdfs:label "Ruimtelijke Ordening vocabulaire"@nl ;
@@ -29,162 +29,130 @@
 #  sh:shapesGraph :ro_str #<- TODO
 .
 
-ro:locatieNaam
-  rdf:type owl:AnnotationProperty ;
+#################################################################
+#    Plan*
+#################################################################
+
+ro:Plan a owl:Class ;
+  rdfs:label "Plan"@nl ;
   rdfs:isDefinedBy :ro ;
-  rdfs:label "locatie naam"@nl ;
+  rdfs:comment "Een plan welke regels beschrijft die geldig zijn voor een bepaald gebied."@nl ;
+  dcterms:subject ro_beg:Plan
 .
 
-ro:naam
-  rdf:type owl:AnnotationProperty ;
+ro:Plangebied a owl:Class ;
+  rdfs:label "Plangebied"@nl ;
   rdfs:isDefinedBy :ro ;
-  rdfs:label "naam"@nl ;
+  rdfs:comment "Het gebied waar een specifiek plan voor geldt."@nl ;
+  dcterms:subject ro_beg:Plangebied ;
+  rdfs:subClassOf nen3610:PlanologischGebied
 .
+
+ro:Planobject a owl:Class
+  rdfs:label "Planobject"@nl ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:comment "Ruimtelijk object welke zich bevindt in een bijbehorend plangebied."@nl ;
+  dcterms:subject ro_beg:Planobject ;
+  rdfs:subClassOf nen3610:PlanologischGebied
+.
+
+#################################################################
+#    labels
+#################################################################
+
+
+#ro:locatieNaam a owl:AnnotationProperty ;   #this property is replaced by locn:geographicName
+#  rdfs:isDefinedBy :ro ;
+#  rdfs:label "locatie naam"@nl
+#.
+
+#ro:naam                                     #this property is replaced by rdfs:label
+#  a owl:AnnotationProperty ;
+#  rdfs:isDefinedBy :ro ;
+#  rdfs:label "naam"@nl ;
+#.
 
 #ro:plangebied
-#  rdf:type owl:ObjectProperty ;
+#  a owl:ObjectProperty ;
 #  rdfs:isDefinedBy :ro ;
 #  rdfs:label "plangebied"@nl ;
 #  rdfs:range nen3610:Plangebied ;
 #.
 
 # ro:planobject
-#   rdf:type owl:ObjectProperty ;
+#   a owl:ObjectProperty ;
 #   rdfs:isDefinedBy :ro ;
 #   rdfs:label "planobject"@nl ;
 #   rdfs:range nen3610:Planobject ;
 # .
 
-ro:thema
-  rdf:type owl:DatatypeProperty ;
+ro:thema a owl:DatatypeProperty ;             #is this a datatype/annotation or perhaps even an objectproperty?
   rdfs:isDefinedBy :ro ;
   rdfs:label "thema"@nl ;
 .
 
-ro:Ondergrond
-  rdf:type owl:Class ;
+#################################################################
+#    Ondergrond
+#################################################################
+
+ro:Ondergrond a owl:Class ;
   rdfs:label "Ondergrond"@nl ;
-  rdfs:subClassOf owl:Thing ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:comment "naamgeving van de gebruikte ondergrond bij het instrument."@nl
 .
 
-ro:ondergrond
-  rdf:type owl:ObjectProperty ;
+ro:GrootschaligeBasiskaart a owl:Class ; #(GBK)
+  rdfs:subClassOf ro:Ondergrond ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:label "Grootschalige basiskaart"@nl
+.
+
+ro:BasisregistratieGrootschaligeTopografie a owl:Class ; #(BGT)
+  rdfs:subClassOf ro:Ondergrond ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:label "Basisregistratie grootschalige topografie"@nl
+.
+
+ro:BasisregistratieTopografie a owl:Class ; #(BRT)
+  rdfs:subClassOf ro:Ondergrond ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:label "Basisregistratie topografie"@nl
+.
+
+ro:BasisregistratieKadaster a owl:Class ; #(BRK)
+  rdfs:subClassOf ro:Ondergrond ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:label "Basisregistratie kadaster"@nl
+.
+
+ro:ondergrond a owl:ObjectProperty ;
   rdfs:domain ro:Plan ;
   rdfs:isDefinedBy :ro ;
   rdfs:label "ondergrond"@nl ;
-  rdfs:range ro:Ondergrond ;
+  rdfs:range ro:Ondergrond
 .
 
-ro:ondergronddatum
-  rdf:type owl:DatatypeProperty ;
+ro:ondergronddatum a owl:DatatypeProperty ;
   rdfs:domain ro:Ondergrond ;
   rdfs:isDefinedBy :ro ;
-  rdfs:label "ondergronddatum"@nl ;
+  rdfs:label "ondergronddatum"@nl
 .
 
-ro:beleid
-  rdf:type owl:ObjectProperty ;
+#################################################################
+#    BeleidInfo
+#################################################################
+
+ro:beleid a owl:ObjectProperty ;
   rdfs:isDefinedBy :ro ;
-  rdfs:label "beleid"@nl ;
+  rdfs:label "beleid"@nl
 .
 
-ro:belang
-  rdf:type owl:DatatypeProperty ;
+ro:belang a owl:DatatypeProperty ;
   rdfs:isDefinedBy :ro ;
-  rdfs:label "belang"@nl ;
+  rdfs:label "belang"@nl
 .
 
-ro:rol
-  rdf:type owl:DatatypeProperty ;
+ro:rol a owl:DatatypeProperty ;
   rdfs:label "rol"@nl ;
-  rdfs:isDefinedBy :ro ;
-.
-
-### instruments
-
-# this should be skos:concepts if I am right.
-
-ro:Instrument
-  rdf:type owl:Class ;
-  rdfs:label "Instrument"@nl ;
-  rdfs:subClassOf owl:Thing ;
-.
-
-ro:instrument
-  rdf:type owl:ObjectProperty ;
-  rdfs:isDefinedBy :ro ;
-  rdfs:label "instrument"@nl ;
-  rdfs:range ro:Instrument ;
-.
-
-ro:amvb
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "amvb"@nl ;
-.
-
-ro:beheersverordening
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "beheersverordening"@nl ;
-.
-
-ro:bestuurlijkeAfspraken
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "bestuurlijke afspraken"@nl ;
-.
-
-ro:coordinatieregeling
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "coordinatieregeling"@nl ;
-.
-
-ro:inpassingsplan
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "inpassingsplan"@nl ;
-.
-
-ro:omgevingsvergunning
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "omgevingsvergunning"@nl ;
-.
-
-ro:proactieveAanwijzing
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "proactieve aanwijzing"@nl ;
-.
-
-ro:reactieveAanwijzing
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "reactieve aanwijzing"@nl ;
-.
-
-ro:vooroverleg
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "vooroverleg"@nl ;
-.
-
-ro:zienswijze
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "zienswijze"@nl ;
-.
-
-ro:verordening
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "verordening"@nl ;
-.
-
-ro:voorbereidingsbesluit
-  rdf:type ro:Instrument ;
-  rdf:type owl:NamedIndividual ;
-  rdfs:label "voorbereidingsbesluit"@nl ;
+  rdfs:isDefinedBy :ro
 .

--- a/Models/common/nen3610/model.ttl
+++ b/Models/common/nen3610/model.ttl
@@ -20,61 +20,39 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-nen3610:GeoObject
-  rdf:type owl:Class ;
+nen3610:GeoObject a owl:Class ;
   dcterms:subject ro_nen3610_beg:GeoObject ;
-  rdfs:label "GeoObject"@nl ;
+  rdfs:label "GeoObject"@nl
 .
 
-nen3610:NEN3610ID
-  rdf:type owl:Class ;
+nen3610:NEN3610ID a owl:Class ;
   dcterms:subject ro_nen3610_beg:NEN3610ID ;
-  rdfs:label "NEN3610ID"@nl ;
+  rdfs:label "NEN3610ID"@nl
 .
 
-nen3610:PlanologischGebied
-  rdf:type owl:Class ;
+nen3610:PlanologischGebied a owl:Class ;
   dcterms:subject ro_nen3610_beg:PlanologischGebied ;
   rdfs:label "Planologisch gebied"@nl ;
-  rdfs:subClassOf nen3610:GeoObject ;
+  rdfs:subClassOf nen3610:GeoObject
 .
 
-nen3610:identificatie
-  rdf:type owl:ObjectProperty ; #functional object property to blank node?
-  rdfs:domain nen3610:GeoObject ;
+nen3610:identificatie a owl:ObjectProperty ; #functional object property to blank node?
   rdfs:label "identificatie"@nl ;
-  rdfs:range nen3610:NEN3610ID ;
+  rdfs:domain nen3610:GeoObject ;
+  rdfs:range nen3610:NEN3610ID
 .
 
-nen3610:lokaalID
-  rdf:type owl:DatatypeProperty ;
+nen3610:lokaalID a owl:DatatypeProperty ;
   rdfs:domain nen3610:NEN3610ID ;
-  rdfs:label "lokaalID"@nl ;
+  rdfs:label "lokaalID"@nl
 .
 
-nen3610:namespace
-  rdf:type owl:DatatypeProperty ;
+nen3610:namespace a owl:DatatypeProperty ;
   rdfs:domain nen3610:NEN3610ID ;
-  rdfs:label "namespace"@nl ;
+  rdfs:label "namespace"@nl
 .
 
-nen3610:versie
-  rdf:type owl:DatatypeProperty ;
+nen3610:versie a owl:DatatypeProperty ;
   rdfs:domain nen3610:NEN3610ID ;
-  rdfs:label "versie"@nl ;
-.
-
-#TODO: Remove all its instances.... iets mee doen
-
-nen3610:Plangebied
-  rdf:type owl:Class ;
-  rdfs:isDefinedBy :ro ;
-  rdfs:label "Plangebied"@nl ;
-  rdfs:subClassOf nen3610:PlanologischGebied ;
-.
-
-nen3610:Planobject
-  rdf:type owl:Class ;
-  rdfs:label "Planobject"@nl ;
-  rdfs:subClassOf nen3610:PlanologischGebied ;
+  rdfs:label "versie"@nl
 .

--- a/Models/common/nen3610/shapes.ttl
+++ b/Models/common/nen3610/shapes.ttl
@@ -13,8 +13,7 @@
 @prefix ro_col: <http://data.informatiehuisruimte.nl/id/collectie/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
-nen3610_str:GeoObject
-  rdf:type sh:NodeShape ; #common
+nen3610_str:GeoObject a sh:NodeShape ;
   sh:targetClass nen3610:GeoObject ;
   sh:sparql [
       sh:message "{$this} is an instance of an abstract class." ;
@@ -29,48 +28,46 @@ WHERE {
   }
 }""" ;
     ] ;
-  sh:property [
-    sh:path nen3610:identificatie ;
-    sh:class nen3610:NEN3610ID ; #should this be a blank node? don't think so.
-    sh:maxCount 1 ;
-    sh:minCount 1 ;
-    ] ;
+  sh:property
+    nen3610_str:GeoObject_identificatie
 .
 
-nen3610_str:NEN3610ID #common
-  rdf:type sh:NodeShape ;
+nen3610_str:GeoObject_identificatie a sh:PropertyShape ;
+    sh:path nen3610:identificatie ;
+    sh:class nen3610:NEN3610ID ;
+    sh:maxCount 1 ;
+    sh:minCount 1
+.
+
+nen3610_str:NEN3610ID a sh:NodeShape ;
   sh:targetClass nen3610:NEN3610ID ;
   sh:property
     nen3610_str:GeoObject_lokaalID ,
     nen3610_str:GeoObject_namespace ,
-    nen3610_str:GeoObject_versie ;
-#   sh:targetClass nen3610:NEN3610ID ; # unnecessary due to the sh:node at nen3610_str:GeoObject_lokaalID?
+    nen3610_str:GeoObject_versie
 .
 
-nen3610_str:GeoObject_lokaalID #common different string lengths for plangebied/object
-  rdf:type sh:PropertyShape ;
+nen3610_str:GeoObject_lokaalID a sh:PropertyShape ; #TODO: different string lengths for plangebied/object
   sh:path nen3610:lokaalID ;
   sh:datatype xsd:string ;
   sh:description "Unieke identificatiecode binnen een registratie"@nl ;
   sh:maxCount 1 ;
   sh:minCount 1 ;
   sh:nodeKind sh:Literal ;
-  sh:pattern "([a-z0-9A-Z\\.\\,\\-]*\\w)" ; # special characters had to be escaped in Topbraid Composer.
+  sh:pattern "([a-z0-9A-Z\\.\\,\\-]*\\w)"  # special characters had to be escaped in Topbraid Composer not sure if all shacl engines require this.
 .
 
-nen3610_str:GeoObject_namespace #common
-  rdf:type sh:PropertyShape ;
+nen3610_str:GeoObject_namespace a sh:PropertyShape ;
   sh:path nen3610:namespace ;
   sh:datatype xsd:string ;
   sh:description "Unieke verwijzing naar een registratie van objecten"@nl ;
   sh:maxCount 1 ;
   sh:minCount 1 ;
   sh:nodeKind sh:Literal ;
-  sh:pattern "([a-z0-9A-Z\\.\\,\\-]*\\w)" ;
+  sh:pattern "([a-z0-9A-Z\\.\\,\\-]*\\w)"
 .
 
-nen3610_str:GeoObject_versie #common
-  rdf:type sh:PropertyShape ;
+nen3610_str:GeoObject_versie a sh:PropertyShape ;
   sh:path nen3610:versie ;
   sh:datatype xsd:string ;
   sh:description "Versie-aanduiding binnen een registratie"@nl ;
@@ -78,47 +75,48 @@ nen3610_str:GeoObject_versie #common
   sh:nodeKind sh:Literal ;
 .
 
-#should this be stored in another folder since it's not nen3610?
-ro_str:PlanlogischGebied rdf:type sh:NodeShape ; #shape defined for IMRO, not nen3610, therefore the prefix.
-  sh:property ro_str:naam ;
-  sh:sparql [
-    sh:message "{$this} is an instance of an abstract class." ;
-    sh:prefixes ro_str:prefixes ;
-    sh:select """
-SELECT DISTINCT $this
-WHERE {
-  $this rdf:type ro:PlanologischGebied  .
-  FILTER NOT EXISTS {
-    $this rdf:type ?class .
-    ?class rdfs:subClassOf ro:PlanologischGebied  .
-  }
-}""" ;
-    ] ;
-#  sh:property ro_str:Planobject_plangebied
-.
+#ro_str:PlanlogischGebied a sh:NodeShape ; #shape defined for IMRO, not nen3610, therefore the prefix.
+#  sh:property ro_str:naam ;
+#  sh:sparql [
+#    sh:message "{$this} is an instance of an abstract class." ;
+#    sh:prefixes ro_str:prefixes ;
+#    sh:select """
+#SELECT DISTINCT $this
+#WHERE {
+#  $this rdf:type ro:PlanologischGebied  .
+#  FILTER NOT EXISTS {
+#    $this rdf:type ?class .
+#    ?class rdfs:subClassOf ro:PlanologischGebied  .
+#  }
+#}""" ;
+#    ] ;
+##  sh:property ro_str:Planobject_plangebied
+#.
 
-nen3610_str:Planobject a sh:NodeShape ; #common
-  sh:targetClass nen3610:Planobject ;
-  sh:property [
-    sh:path nen3610:identificatie ;
+#nen3610_str:Planobject a sh:NodeShape ; #common
+#  sh:targetClass nen3610:Planobject ;
+#  sh:property [
+#    sh:path nen3610:identificatie ;
 #    sh:datatype xsd:string ; already declared
-    sh:maxLength 32 ;
-    ] ;
-  sh:sparql [
-      sh:message "{$this} is an instance of an abstract class." ;
-      sh:prefixes ro_str:prefixes ;
-      sh:select """
-SELECT DISTINCT $this
-WHERE {
-  $this rdf:type ro:Planobject  .
-  FILTER NOT EXISTS {
-    $this rdf:type ?class .
-    ?class rdfs:subClassOf ro:Planobject  .
-  }
-}""" ;
-    ] ;
-#  sh:property ro_str:Planobject_plangebied
-.
+#    sh:maxLength 32 ;
+#    ] ;
+#  sh:sparql [
+#      sh:message "{$this} is an instance of an abstract class." ;
+#      sh:prefixes ro_str:prefixes ;
+#      sh:select """
+#SELECT DISTINCT $this
+#WHERE {
+#  $this rdf:type ro:Planobject  .
+#  FILTER NOT EXISTS {
+#    $this rdf:type ?class .
+#    ?class rdfs:subClassOf ro:Planobject  .
+#  }
+#}""" ;
+#    ]
+##  sh:property ro_str:Planobject_plangebied
+#.
+
+
 #ro_str:Planobject_plangebied a sh:PropertyShape ;
 #  sh:path ro:plangebied ;
 #  sh:class ro:Plangebied ;
@@ -128,28 +126,28 @@ WHERE {
 #.
 ## not all 'besluitvakken' have a planobject, some have a 'besluitgebied'
 
-ro_str:Plangebied rdf:type sh:NodeShape ; #common
-  sh:targetClass nen3610:Plangebied ;
-  sh:property
-    ro_str:Plangebied_locatieNaam ,
-    ro_str:Plangebied_planstatus ,
-    ro_str:Plangebied_ondergrond ;
-  sh:property [
-    sh:path nen3610:identificatie ;
-#    sh:datatype xsd:string ; already declared, as well as multiplicity
-    sh:maxLength 23 ;
-    ] ;
-  sh:sparql [
-    sh:message "{$this} is an instance of an abstract class." ;
-    sh:prefixes ro_str:prefixes ;
-    sh:select """
-SELECT DISTINCT $this
-WHERE {
-  $this rdf:type ro:Plangebied  .
-  FILTER NOT EXISTS {
-    $this rdf:type ?class .
-    ?class rdfs:subClassOf ro:Plangebied  .
-  }
-}""" ;
-    ] ;
-.
+#ro_str:Plangebied rdf:type sh:NodeShape ;
+#  sh:targetClass nen3610:Plangebied ;
+#  sh:property
+#    ro_str:Plangebied_locatieNaam ,
+#    ro_str:Plangebied_planstatus ,
+#    ro_str:Plangebied_ondergrond ;
+#  sh:property [
+#    sh:path nen3610:identificatie ;
+##    sh:datatype xsd:string ; already declared, as well as multiplicity
+#    sh:maxLength 23 ;
+#    ] ;
+#  sh:sparql [
+#    sh:message "{$this} is an instance of an abstract class." ;
+#    sh:prefixes ro_str:prefixes ;
+#    sh:select """
+#SELECT DISTINCT $this
+#WHERE {
+#  $this rdf:type ro:Plangebied  .
+#  FILTER NOT EXISTS {
+#    $this rdf:type ?class .
+#    ?class rdfs:subClassOf ro:Plangebied  .
+#  }
+#}""" ;
+#    ] ;
+#.

--- a/Models/common/planstatus/model.ttl
+++ b/Models/common/planstatus/model.ttl
@@ -20,35 +20,36 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-#should probably be used at ro:RuimtelijkInstrument, not at its subclasses
-ro:Planstatus
-  rdf:type owl:Class ;
+#################################################################
+#    Planstatus
+#################################################################
+
+ro:Planstatus a owl:Class ;
   rdfs:label "Planstatus"@nl ;
-  rdfs:isDefinedBy :ro ;
+  rdfs:isDefinedBy :ro
 .
 
 ro:status a owl:ObjectProperty ;
   rdfs:label "status"@nl ;
   rdfs:isDefinedBy :ro ;
-  rdfs:domain ro:Planstatus  ;
+  rdfs:domain ro:Planstatus
 .
 
-ro:vaststellingsbesluit
-  rdf:type owl:ObjectProperty ;
+ro:vaststellingsbesluit a owl:ObjectProperty ;
   rdfs:label "vaststellingsbesluit"@nl ;
   rdfs:domain ro:Planstatus ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:besluitnummer
-  rdf:type owl:DatatypeProperty ;
+ro:besluitnummer a owl:DatatypeProperty ;
   rdfs:label "besluitnummer"@nl ;
   rdfs:domain ro:Planstatus ;
+  rdfs:isDefinedBy :ro
 .
 
-#TODO: Align with specific models
-ro:toekenningsdatum #this property was reused somewhere else, should it still be in this folder?
-  rdf:type owl:DatatypeProperty ;
+ro:toekenningsdatum a owl:DatatypeProperty ;
   rdfs:label "toekenningsdatum"@nl ;
   rdfs:domain ro:Planstatus ;
   rdfs:range xsd:date ;
+  rdfs:isDefinedBy :ro
 .

--- a/Models/common/planstatus/shapes.ttl
+++ b/Models/common/planstatus/shapes.ttl
@@ -14,43 +14,40 @@
 @prefix ro_col: <http://data.informatiehuisruimte.nl/id/collectie/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
-ro_str:RuimtelijkInstrument_planstatus rdf:type sh:PropertyShape ; #common
-  sh:path ro:planstatus ;
-  sh:class ro:Planstatus ; #in order to avoid a blank node
-  sh:minCount 1 ;
-  sh:maxCount 1 ;
-#  sh:node ro_str:Planstatus ; instead used sh:targetClass
-.
 
-ro_str:Planstatus rdf:type sh:NodeShape ; #common
+#################################################################
+#    Planstatus
+#################################################################
+
+ro_str:Planstatus rdf:type sh:NodeShape ;
   sh:targetClass ro:Planstatus ;
-  sh:property # and instance of class planstatus has four properties.
+  sh:property
     ro_str:Planstatus_status ,
-    ro_str:Planstatus_datum ,
+    ro_str:Planstatus_toekenningsdatum ,
     ro_str:Planstatus_vaststellingsbesluit ,
-    ro_str:Planstatus_besluitnummer ;
+    ro_str:Planstatus_besluitnummer
 .
 
 ro_str:Planstatus_status rdf:type sh:PropertyShape ; #common
-  sh:path ro:status ; #the structuurvisieplangebied_R model.ttl file uses ro:planstatus, this is to be removed when the common model takes effect)
+  sh:path ro:status ;
   sh:class skos:Concept ;
   sh:nodeKind sh:IRI ;
   sh:minCount 1 ;
   sh:maxCount 1 ;
-  sh:node [ # I would advocate the use of a skos:Collections as defined in the bestemmingsplan model file.
+  sh:node [
     sh:property [
       sh:path [ sh:inversePath skos:member ] ;
-      sh:hasValue ro_col:Planstatussen ;  #defined in common file.
+      sh:hasValue ro_col:Planstatussen ;
     ]
   ]
 .
 
-ro_str:Planstatus_datum rdf:type sh:PropertyShape ;  #common
-  sh:path ro:datum ;
+ro_str:Planstatus_toekenningsdatum rdf:type sh:PropertyShape ;  #common
+  sh:path ro:toekenningsdatum ;
   sh:nodeKind sh:Literal ;
   sh:datatype xsd:date ;
   sh:minCount 1 ;
-  sh:maxCount 1 ;
+  sh:maxCount 1
 .
 
 ro_str:Planstatus_vaststellingsbesluit
@@ -67,13 +64,11 @@ ro_str:Planstatus_vaststellingsbesluit
         sh:path ro:status ;
         sh:hasValue ro_beg:Vastgesteld_Planstatus ;
       ] )
-    ]
-    [
+    ] [
     sh:and ( [
         sh:path ro:vaststellingsbesluit ;
         sh:maxCount 0 ;
-      ]
-      [
+      ] [
         sh:not [
           sh:path ro:status ;
           sh:hasValue ro_beg:Vastgesteld_Planstatus ;
@@ -91,18 +86,15 @@ ro_str:Planstatus_besluitnummer
         sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-      ]
-      [
+      ] [
         sh:path ro:status ;
         sh:hasValue ro_beg:Vastgesteld_Planstatus ;
       ] )
-    ]
-    [
+    ] [
     sh:and ( [
         sh:path ro:vaststellingsbesluit ;
         sh:maxCount 0 ;
-      ]
-      [
+      ] [
         sh:not [
           sh:path ro:status ;
           sh:hasValue ro_beg:Vastgesteld_Planstatus ;

--- a/Models/common/shapes.ttl
+++ b/Models/common/shapes.ttl
@@ -80,7 +80,8 @@ ro_str:Plan_dataset a sh:propertyShape ;
 ro_str:Planobject a sh:NodeShape ;
   sh:targetClass ro:Planobject ;
   sh:property
-    ro_str:Planobject_isPartOf
+    ro_str:Planobject_isPartOf ,
+    ro_str:Planobject_identificatie_lokaalID ,
     ro_str:Plan_label
 .
 
@@ -91,6 +92,12 @@ ro_str:Planobject_isPartOf a sh:PropertyShape ;
   sh:maxCount 1
 .
 
+ro_str:Planobject_identificatie_lokaalID a sh:PropertyShape ;
+  sh:path ( nen3610:identificatie nen3610:lokaalID ) ;
+  sh:datatype xsd:string ;
+  sh:maxLength 32
+.
+
 #################################################################
 #    Plangebied
 #################################################################
@@ -98,7 +105,14 @@ ro_str:Planobject_isPartOf a sh:PropertyShape ;
 ro_str:Plangebied a sh:NodeShape ;
   sh:targetClass ro:Plangebied ;
   sh:property
-    ro_str:Plangebied_geometry
+    ro_str:Plangebied_geometry ,
+    ro_str:Plangebied_identificatie_lokaalID
+.
+
+ro_str:Plangebied_identificatie_lokaalID a sh:PropertyShape ;
+  sh:path ( nen3610:identificatie nen3610:lokaalID ) ;
+  sh:datatype xsd:string ;
+  sh:maxLength 23
 .
 
 ro_str:Plangebied_geometrie a sh:PropertyShape ;

--- a/Models/common/shapes.ttl
+++ b/Models/common/shapes.ttl
@@ -14,6 +14,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix locn: <http://www.w3.org/ns/locn#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
 
 #################################################################
 #    Plan
@@ -26,7 +28,8 @@ ro_str:Plan a sh:NodeShape ;
     ro_str:Plan_hasPart ,
     ro_str:Plan_label ,          #formerly ro_str:naam
     ro_str:Plan_geographicName , #formerly ro_str:Plangebied_locatieNaam
-    ro_str:Plan_ondergrond
+    ro_str:Plan_ondergrond ,
+    ro_str:Plan_dataset
 .
 
 ro_str:Plan_spatial a sh:PropertyShape ;
@@ -59,6 +62,16 @@ ro_str:Plan_ondergrond a sh:PropertyShape ;
   sh:minCount 1 ;
   sh:node ro_str:Plangebied_Ondergrond ;
 .
+
+ro_str:Plan_dataset a sh:propertyShape ;
+  sh:path rdf:type ;
+  sh:qualifiedValueShape [
+    sh:class void:Dataset ;
+  ] ;
+  sh:qualifiedMinCount 1 ;
+  sh:qualifiedMaxCount 1 ;
+.
+
 
 #################################################################
 #    Planobject

--- a/Models/common/shapes.ttl
+++ b/Models/common/shapes.ttl
@@ -29,7 +29,8 @@ ro_str:Plan a sh:NodeShape ;
     ro_str:Plan_label ,          #formerly ro_str:naam
     ro_str:Plan_geographicName , #formerly ro_str:Plangebied_locatieNaam
     ro_str:Plan_ondergrond ,
-    ro_str:Plan_dataset
+    ro_str:Plan_dataset ,
+    ro_str:Plan_planstatus
 .
 
 ro_str:Plan_spatial a sh:PropertyShape ;
@@ -72,6 +73,12 @@ ro_str:Plan_dataset a sh:propertyShape ;
   sh:qualifiedMaxCount 1 ;
 .
 
+ro_str:Plan_planstatus rdf:type sh:PropertyShape ;
+  sh:path ro:planstatus ;
+  sh:class ro:Planstatus ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+.
 
 #################################################################
 #    Planobject

--- a/Models/common/shapes.ttl
+++ b/Models/common/shapes.ttl
@@ -12,53 +12,112 @@
 @prefix ro: <http://data.informatiehuisruimte.nl/def/ro#> .
 @prefix ro_col: <http://data.informatiehuisruimte.nl/id/collectie/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefic locn: <http://www.w3.org/ns/locn#> .
 
-ro_str:RuimtelijkInstrument a sh:Nodeshape ;
-  sh:targetClass ro:RuimtelijkInstrument ;
+
+#################################################################
+#    Plan
+#################################################################
+
+ro_str:Plan a sh:NodeShape ;
+  sh:targetClass ro:Plan ;
   sh:property
-    ro_str:RuimtelijkInstrument_planstatus ;
+    ro_str:Plan_spatial ,
+    ro_str:Plan_hasPart ,
+    ro_str:Plan_label ,          #formerly ro_str:naam
+    ro_str:Plan_geographicName , #formerly ro_str:Plangebied_locatieNaam
+    ro_str:Plan_ondergrond
 .
 
-ro_str:naam rdf:type sh:PropertyShape ; #TODO: ScopedName
-  sh:path ro:naam ;
+ro_str:Plan_spatial a sh:PropertyShape ;
+  sh:path dct:spatial ;
+  sh:class ro:Plangebied ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+.
+
+ro_str:Plan_hasPart a sh:PropertyShape ;
+  sh:path dct:hasPart ;
+  sh:class ro:Planobject ;
+.
+
+ro_str:Plan_label rdf:type sh:PropertyShape ; #TODO: ScopedName
+  sh:path rdfs:label ;
   sh:minCount 1 ;
   sh:maxCount 1 ;
   sh:datatype xsd:string ;
 .
 
-#TODO: convert to RuimtelijkInstrument
-ro_str:Plangebied_locatieNaam
-  rdf:type sh:PropertyShape ; #common
-  sh:path ro:locatieNaam ;
+ro_str:Plan_geographicName a sh:PropertyShape ;
+  sh:path locn:geographicName ;
   sh:nodeKind sh:Literal ;
   sh:datatype xsd:string ;
 .
 
-ro_str:Plangebied_ondergrond a sh:PropertyShape ;
+ro_str:Plan_ondergrond a sh:PropertyShape ;
   sh:path ro:ondergrond ;
   sh:minCount 1 ;
   sh:node ro_str:Plangebied_Ondergrond ;
 .
+
+#################################################################
+#    Planobject
+#################################################################
+
+ro_str:Planobject a sh:NodeShape ;
+  sh:targetClass ro:Planobject ;
+  sh:property
+    ro_str:Planobject_isPartOf
+    ro_str:Plan_label
+.
+
+ro_str:Planobject_isPartOf a sh:PropertyShape ;
+  sh:path dct:isPartOf ;
+  sh:class ro:Plan ;
+  sh:minCount 1 ;
+  sh:maxCount 1
+.
+
+#################################################################
+#    Plangebied
+#################################################################
+
+ro_str:Plangebied a sh:NodeShape ;
+  sh:targetClass ro:Plangebied ;
+  sh:property
+    ro_str:Plangebied_geometry
+.
+
+ro_str:Plangebied_geometrie a sh:PropertyShape ;
+  sh:path ogc:geometry ;
+  sh:class ogc:Geometry ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+.
+
+#ro_str:naam rdf:type sh:PropertyShape ; #TODO: ScopedName
+#  sh:path ro:naam ;
+#  sh:minCount 1 ;
+#  sh:maxCount 1 ;
+#  sh:datatype xsd:string ;
+#.
+
+#ro_str:Plangebied_locatieNaam
+#  rdf:type sh:PropertyShape ; #common
+#  sh:path ro:locatieNaam ;
+#  sh:nodeKind sh:Literal ;
+#  sh:datatype xsd:string ;
+#.
+
+#################################################################
+#    Ondergrond
+#################################################################
 
 ro_str:Plangebied_Ondergrond a sh:NodeShape ;
   sh:property
     ro:Ondergrond_ondergrondtype ,
     ro:ondergrond_datum ;
 .
-
-#think this was the same as ro_str:naam at nen3610:planologischgebied
-#ro_str:Plangebied_naam a sh:PropertyShape ;
-#  sh:path ro:naam ;
-#  sh:nodeKind sh:Literal ;
-#  sh:datatype xsd:string ;
-#  sh:minCount 1 ;
-#  sh:maxCount 1
-#.
-
-#should be discussed with team
-#plangebied ro:ondergrond X . x is an instance of class ro:Ondergrond
-# x ro:ondergrondtype Y . y is a named skos:concept
-# x ro:datum Z . z is a date in xsd:date format
 
 ro_str:Ondergrond_ondergrondtype
   rdf:type sh:PropertyShape ;
@@ -69,7 +128,7 @@ ro_str:Ondergrond_ondergrondtype
 
 ro_str:ondergrond_datum
   rdf:type sh:PropertyShape ;
-  sh:path ro:datum ;
+  sh:path ro:ondergronddatum ;
   sh:minCount 1 ;
   sh:maxCount 1 ;
 .
@@ -91,11 +150,4 @@ ro_str:prefixes #should we store this here?
       sh:namespace "http://data.informatiehuisruimte.nl/def/nen3610#"^^xsd:anyURI ;
       sh:prefix "nen3610" ;
     ] ;
-.
-
-ro_str:RuimtelijkPlanOfBesluit_SV
-  rdf:type sh:NodeShape ;
-  sh:in (
-    ro:Structuurvisie
-    ) ;
 .

--- a/Models/common/shapes.ttl
+++ b/Models/common/shapes.ttl
@@ -12,8 +12,8 @@
 @prefix ro: <http://data.informatiehuisruimte.nl/def/ro#> .
 @prefix ro_col: <http://data.informatiehuisruimte.nl/id/collectie/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefic locn: <http://www.w3.org/ns/locn#> .
-
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 
 #################################################################
 #    Plan
@@ -95,20 +95,6 @@ ro_str:Plangebied_geometrie a sh:PropertyShape ;
   sh:maxCount 1 ;
 .
 
-#ro_str:naam rdf:type sh:PropertyShape ; #TODO: ScopedName
-#  sh:path ro:naam ;
-#  sh:minCount 1 ;
-#  sh:maxCount 1 ;
-#  sh:datatype xsd:string ;
-#.
-
-#ro_str:Plangebied_locatieNaam
-#  rdf:type sh:PropertyShape ; #common
-#  sh:path ro:locatieNaam ;
-#  sh:nodeKind sh:Literal ;
-#  sh:datatype xsd:string ;
-#.
-
 #################################################################
 #    Ondergrond
 #################################################################
@@ -132,6 +118,11 @@ ro_str:ondergrond_datum
   sh:minCount 1 ;
   sh:maxCount 1 ;
 .
+
+#################################################################
+#    Prefixes
+#################################################################
+
 
 ro_str:prefixes #should we store this here?
   sh:declare [

--- a/Models/common/verwijzing/model.ttl
+++ b/Models/common/verwijzing/model.ttl
@@ -58,12 +58,12 @@ ro:Beleid a owl:Class ;
   rdfs:isDefinedBy :ro
 .
 
-ro:Regel_met_Voorbereidingsbescherming a owl:Class ;
+ro:RegelMetVoorbereidingsbescherming a owl:Class ;
   rdfs:label "Regel met Voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
 .
 
-ro:Regel_zonder_Voorbereidingsbescherming a owl:Class ;
+ro:RegelZonderVoorbereidingsbescherming a owl:Class ;
   rdfs:label "Regel zonder Voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
   rdfs:isDefinedBy :ro
@@ -75,7 +75,7 @@ ro:Regels a owl:Class ;
   rdfs:isDefinedBy :ro
 .
 
-ro:Beleid_Gemandateerd_aan_GS a owl:Class ;
+ro:BeleidGemandateerdAanGS a owl:Class ;
   rdfs:label "Beleid Gemandateerd aan GS"@nl ;
   rdfs:subClassOf ro:Tekst ;
   rdfs:isDefinedBy :ro
@@ -99,36 +99,36 @@ ro:Bijlage a owl:Class ;
   rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Besluitdocument a owl:Class ;
+ro:BijlageBesluitdocument a owl:Class ;
   rdfs:label "Bijlage Besluitdocument"@nl ;
   rdfs:subClassOf ro:Tekst ;
   rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Besluittekst a owl:Class ;
+ro:BijlageBesluittekst a owl:Class ;
   rdfs:label "Bijlage Besluittekst"@nl ;
   rdfs:subClassOf ro:Tekst ;
   rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Regel_met_voorbereidingsbescherming a owl:Class ;
+ro:BijlageRegelMetVoorbereidingsbescherming a owl:Class ;
   rdfs:label "Bijlage Regel met voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
 .
 
-ro:Bijlage_Regel_zonder_voorbereidingsbescherming a owl:Class ;
+ro:BijlageRegelZonderVoorbereidingsbescherming a owl:Class ;
   rdfs:label "Bijlage Regel zonder voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
   rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Regels a owl:Class ;
+ro:BijlageRegels a owl:Class ;
   rdfs:label "Bijlage Regels"@nl ;
   rdfs:subClassOf ro:Tekst ;
   rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Toelichting a owl:Class ;
+ro:BijlageToelichting a owl:Class ;
   rdfs:label "Bijlage Toelichting"@nl ;
   rdfs:subClassOf ro:Tekst ;
   rdfs:isDefinedBy :ro
@@ -260,7 +260,7 @@ ro:uitgewerktIn a owl:ObjectProperty ;
 ro:gebruiktInformatieUit a owl:ObjectProperty ; #does this IRI deviate too much from 'informatie in extern plan/besluit'?
   rdfs:subPropertyOf ro:externPlan ;
   rdfs:isDefinedBy :ro ;
-  dcterms:subject ro_beg:gebruiktInformatieUit
+  dcterms:subject ro_beg:gebruiktInformatieUit ;
 .
 
 ro:tenGevolgeVan a owl:ObjectProperty ;

--- a/Models/common/verwijzing/model.ttl
+++ b/Models/common/verwijzing/model.ttl
@@ -20,201 +20,209 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-ro:verwijzing
-  rdf:type rdf:Property ;
+ro:verwijzing a rdf:Property ;
   rdfs:label "verwijzing"@nl ;
   rdfs:isDefinedBy :ro ;
 .
 
-### Tekst
-#TODO: adjusted to Naming Conventions
+### TODO DOCO?
 
-ro:tekstReferentie
-  rdf:type owl:AnnotationProperty ;
-  rdfs:label "tekstverwijzing"@nl ;
-.
+#################################################################
+#    Tekst
+#################################################################
 
-ro:Tekst
-  rdf:type owl:Class ;
+#ro:tekstReferentie a owl:AnnotationProperty ;
+#  rdfs:label "tekstverwijzing"@nl ;
+#.
+
+ro:Tekst a owl:Class ;
   rdfs:label "Tekst"@nl ;
   rdfs:subClassOf owl:Thing ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Toelichting
-  rdf:type owl:Class ;
+ro:tekst a owl:ObjectProperty ;
+  rdfs:label "tekst"@nl ;
+  rdfs:isDefinedBy :ro
+.
+
+ro:Toelichting a owl:Class ;
   rdfs:label "Toelichting"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Beleid
-  rdf:type owl:Class ;
+ro:Beleid a owl:Class ;
   rdfs:label "Beleid"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Regel_met_Voorbereidingsbescherming
-  rdf:type owl:Class ;
+ro:Regel_met_Voorbereidingsbescherming a owl:Class ;
   rdfs:label "Regel met Voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
 .
 
-ro:Regel_zonder_Voorbereidingsbescherming
-  rdf:type owl:Class ;
+ro:Regel_zonder_Voorbereidingsbescherming a owl:Class ;
   rdfs:label "Regel zonder Voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Regels
-  rdf:type owl:Class ;
+ro:Regels a owl:Class ;
   rdfs:label "Regels"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Beleid_Gemandateerd_aan_GS
-  rdf:type owl:Class ;
+ro:Beleid_Gemandateerd_aan_GS a owl:Class ;
   rdfs:label "Beleid Gemandateerd aan GS"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Besluitdocument
-  rdf:type owl:Class ;
+ro:Besluitdocument a owl:Class ;
   rdfs:label "Besluitdocument"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Besluittekst
-  rdf:type owl:Class ;
+ro:Besluittekst a owl:Class ;
   rdfs:label "Besluittekst"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage
-  rdf:type owl:Class ;
+ro:Bijlage a owl:Class ;
   rdfs:label "Bijlage"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Besluitdocument
-  rdf:type owl:Class ;
+ro:Bijlage_Besluitdocument a owl:Class ;
   rdfs:label "Bijlage Besluitdocument"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Besluittekst
-  rdf:type owl:Class ;
+ro:Bijlage_Besluittekst a owl:Class ;
   rdfs:label "Bijlage Besluittekst"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Regel_met_voorbereidingsbescherming
-  rdf:type owl:Class ;
+ro:Bijlage_Regel_met_voorbereidingsbescherming a owl:Class ;
   rdfs:label "Bijlage Regel met voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
 .
 
-ro:Bijlage_Regel_zonder_voorbereidingsbescherming
-  rdf:type owl:Class ;
+ro:Bijlage_Regel_zonder_voorbereidingsbescherming a owl:Class ;
   rdfs:label "Bijlage Regel zonder voorbereidingsbescherming"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Regels
-  rdf:type owl:Class ;
+ro:Bijlage_Regels a owl:Class ;
   rdfs:label "Bijlage Regels"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Bijlage_Toelichting
-  rdf:type owl:Class ;
+ro:Bijlage_Toelichting a owl:Class ;
   rdfs:label "Bijlage Toelichting"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Document
-  rdf:type owl:Class ;
+ro:Document a owl:Class ;
   rdfs:label "Document"@nl ;
   rdfs:subClassOf ro:Tekst ;
+  rdfs:isDefinedBy :ro
 .
 
+#################################################################
+#    Illustratie
+#################################################################
 
-### Illustratie
-
-ro:Illustratie
-  rdf:type owl:Class ;
+ro:Illustratie a owl:Class ;
   rdfs:label "Illustratie"@nl ;
-  rdfs:subClassOf owl:Thing ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Afbeelding
-  rdf:type owl:Class ;
+ro:Afbeelding a owl:Class ;
   rdfs:label "Afbeelding"@nl ;
   rdfs:subClassOf ro:Illustratie ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:Kaart
-  rdf:type owl:Class ;
+ro:Kaart a owl:Class ;
   rdfs:label "Kaart"@nl ;
   rdfs:subClassOf ro:Illustratie ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:illustratie
-  rdf:type owl:AnnotationProperty ;
-  rdfs:label "illustratie"@nl ;
-  rdfs:subPropertyOf ro:verwijzing ;
+ro:illustratie a owl:AnnotationProperty ;
+  rdfs:label "illustratie"@nl
+  rdfs:isDefinedBy :ro
 .
 
-ro:afbeeldingReferentie
-  rdf:type owl:AnnotationProperty ;
-  rdfs:label "afbeeldingReferentie"@nl ;
-  rdfs:subPropertyOf ro:illustratie ;
-.
-
-ro:kaartReferentie
-  rdf:type owl:AnnotationProperty ;
-  rdfs:label "kaartReferentie"@nl ;
-  rdfs:subPropertyOf ro:illustratie ;
-.
-
-ro:illustratieverwijzing #no longer used in any shapes, forgot to remove?
-  rdf:type owl:ObjectProperty ;
-  rdfs:label "illustratieverwijzing"@nl ;
-.
-
-ro:legendaNaam
-  rdf:type owl:DatatypeProperty ;
+ro:legendaNaam a owl:AnnotationProperty ;
   rdfs:isDefinedBy :ro ;
-  rdfs:label "legenda naam"@nl ;
+  rdfs:label "legenda naam"@nl
 .
 
-### cartografie
+ro:illustratieNaam a owl:AnnotationProperty ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:label "illustratie naam"@nl
+.
 
-ro:cartografie
-  rdf:type owl:ObjectProperty ;
+#ro:afbeeldingReferentie
+#  rdf:type owl:AnnotationProperty ;
+#  rdfs:label "afbeeldingReferentie"@nl ;
+#  rdfs:subPropertyOf ro:illustratie ;
+#.
+
+#ro:kaartReferentie
+#  rdf:type owl:AnnotationProperty ;
+#  rdfs:label "kaartReferentie"@nl ;
+#  rdfs:subPropertyOf ro:illustratie ;
+#.
+
+#ro:illustratieverwijzing a owl:Class ;
+#  rdfs:label "illustratieverwijzing"@nl ;
+#.
+
+#################################################################
+#    Cartografie
+#################################################################
+
+ro:cartografie a owl:ObjectProperty ;
   rdfs:label "cartografie"@nl ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:kaartNaam
-  rdf:type owl:DatatypeProperty ;
+ro:kaartNaam a owl:AnnotationProperty ;
   rdfs:label "kaart naam"@nl ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:kaartNummer
-  rdf:type owl:DatatypeProperty ;
+ro:kaartNummer a owl:DatatypeProperty ;
   rdfs:label "kaart nummer"@nl ;
+  rdfs:isDefinedBy :ro
 .
 
-ro:symboolCode
-  rdf:type owl:DatatypeProperty ;
+ro:symboolCode a owl:DatatypeProperty ;
   rdfs:label "symbool code"@nl ;
+  rdfs:isDefinedBy :ro
 .
 
-### extern plan
+#################################################################
+#    Extern plan
+#################################################################
 
-ro:externPlan
-  rdf:type owl:ObjectProperty ;
+ro:externPlan a owl:ObjectProperty ;
   rdfs:label "extern plan"@nl ;
-  rdfs:isDefinedBy :ro ;
-  rdfs:subPropertyOf ro:verwijzing ;
+  rdfs:isDefinedBy :ro
 .
 
 #redundant if we point to IRIs of external plans.
@@ -222,54 +230,51 @@ ro:externPlan
 #  rdf:type owl:DatatypeProperty ;
 #  rdfs:domain ro:ExternPlan ;
 #  rdfs:isDefinedBy :ro ;
-#  rdfs:label "idn"@nl ;
+#  rdfs:label "idn"@nl
 #.
 
-ro:muteert
-  rdf:type owl:ObjectProperty ;
+ro:muteert a owl:ObjectProperty ;
   rdfs:subPropertyOf ro:externPlan ;
   rdfs:isDefinedBy :ro ;
-  dcterms:subject ro_beg:muteert ;
+  dcterms:subject ro_beg:muteert
 .
 
-ro:vervangt
-  rdf:type owl:ObjectProperty ;
+ro:vervangt a owl:ObjectProperty ;
   rdfs:subPropertyOf ro:externPlan ;
   rdfs:isDefinedBy :ro ;
-  dcterms:subject ro_beg:vervangt ;
+  dcterms:subject ro_beg:vervangt
 .
 
-ro:uitTeWerkenIn
-  rdf:type owl:ObjectProperty ;
+ro:uitTeWerkenIn a owl:ObjectProperty ;
   rdfs:subPropertyOf ro:externPlan ;
   rdfs:isDefinedBy :ro ;
-#  dcterms:subject ro_beg: ;
+  dcterms:subject ro_beg:uitTeWerkenIn
 .
 
-ro:uitgewerktIn
-  rdf:type owl:ObjectProperty ;
+ro:uitgewerktIn a owl:ObjectProperty ;
   rdfs:subPropertyOf ro:externPlan ;
   rdfs:isDefinedBy :ro ;
-#  dcterms:subject ro_beg: ;
+  dcterms:subject ro_beg:uitgewerktIn
 .
 
-ro:gebruiktInformatieUit
-  rdf:type owl:ObjectProperty ; #does this IRI deviate too much from 'informatie in extern plan/besluit'?
+ro:gebruiktInformatieUit a owl:ObjectProperty ; #does this IRI deviate too much from 'informatie in extern plan/besluit'?
   rdfs:subPropertyOf ro:externPlan ;
   rdfs:isDefinedBy :ro ;
-#  dcterms:subject ro_beg:vervangt ;
+  dcterms:subject ro_beg:gebruiktInformatieUit
 .
 
-ro:tenGevolgeVan
-  rdf:type owl:ObjectProperty ;
+ro:tenGevolgeVan a owl:ObjectProperty ;
   rdfs:subPropertyOf ro:externPlan ;
   rdfs:isDefinedBy :ro ;
-  dcterms:subject ro_beg:tenGevolgeVan ;
+  dcterms:subject ro_beg:tenGevolgeVan
 .
 
-### norm
+#################################################################
+#    norm
+#################################################################
 
-ro:verwijzingNorm
-  rdf:type owl:DatatypeProperty ;
+
+ro:norm a owl:ObjectProperty ;
   rdfs:label "verwijzing norm"@nl ;
+  rdfs:isDefinedBy
 .

--- a/Models/common/verwijzing/shapes.ttl
+++ b/Models/common/verwijzing/shapes.ttl
@@ -13,20 +13,23 @@
 @prefix ro_col: <http://data.informatiehuisruimte.nl/id/collectie/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
-### tekst
+##################################################################
+#    Illustratie
+#################################################################
 
 #here we define that all instances of ro:Tekst should have a reference to the tekst as a string.
-ro_str:Tekst rdf:type sh:NodeShape ;
-  sh:targetClass ro:Tekst ;
-  sh:property [
-    sh:path ro:tekstverwijzing ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:datatype xsd:string ;
-    ] ;
-.
+#date - 4-11-17: instances are the reference, they no longer contain a reference.
+#ro_str:Tekst rdf:type sh:NodeShape ;
+#  sh:targetClass ro:Tekst ;
+#  sh:property [
+#    sh:path ro:tekstverwijzing ;
+#    sh:minCount 1 ;
+#    sh:maxCount 1 ;
+#    sh:datatype xsd:string ;
+#    ] ;
+#.
 
-ro_str:TeksttypePG_BP rdf:type sh:NodeShape ;
+ro_str:TeksttypePG_BP a sh:NodeShape ;
   sh:property [
     sh:path rdf:type ;
     sh:in (
@@ -38,7 +41,7 @@ ro_str:TeksttypePG_BP rdf:type sh:NodeShape ;
   ]
 .
 
-ro_str:Teksttype_SV rdf:type sh:NodeShape ;
+ro_str:Teksttype_SV a sh:NodeShape ;
   sh:property [
     sh:path rdf:type ;
     sh:in (
@@ -48,7 +51,7 @@ ro_str:Teksttype_SV rdf:type sh:NodeShape ;
   ] ;
 .
 
-ro_str:TeksttypePG_SV rdf:type sh:NodeShape ;
+ro_str:TeksttypePG_SV a sh:NodeShape ;
   sh:property [
     sh:path rdf:type ;
     sh:in (
@@ -68,27 +71,29 @@ ro_str:Teksttype_BP a sh:NodeShape ;
   ] ;
 .
 
-ro_str:Teksttype_PSV rdf:type sh:NodeShape ;
+ro_str:Teksttype_PSV a sh:NodeShape ;
   sh:property [
     sh:path rdf:type ;
     sh:in (
       ro:Beleid
-      ro:Beleid_Gemandateerd_aan_GS #TODO: adjusted to Naming Conventions
+      ro:BeleidGemandateerdAanGS
       ro:Toelichting
     ) ] ;
 .
 
-### illustratie
+#################################################################
+#    Illustratie
+#################################################################
 
-ro_str:Illustratie #illutration is an entity of type either kaart or afbeelding with a reference to its storage location. We don't need sh:in in this case.
-  rdf:type sh:NodeShape ;
-  sh:property [
-    sh:path ro:illustratieverwijzing ;
-#    sh:datatype xsd:string ; #object can be a hyperlink, would we want to store it as a string?
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ]
-.
+#no longer used as the instance is the reference, it does not contain the reference as an attribute.
+#ro_str:Illustratie a sh:NodeShape ;
+#  sh:property [
+#    sh:path ro:illustratieverwijzing ;
+##    sh:datatype xsd:string ; #object can be a hyperlink, would we want to store it as a string?
+#    sh:minCount 1 ;
+#    sh:maxCount 1 ;
+#  ]
+#.
 
 ro_str:Illustratie_legendaNaam rdf:type sh:NodeShape ; #can I treat a nodeshape as a propertyshape?
   sh:path ro:legendaNaam ;
@@ -102,30 +107,42 @@ ro_str:Illustratie_IllustratieNaam rdf:type sh:NodeShape ; #can I treat a nodesh
   sh:maxCount 1 ;
 .
 
-### cartografie
+#################################################################
+#    Cartografie
+#################################################################
 
-# TODO clean up.
 ro_str:cartografieInfo rdf:type sh:NodeShape ;
-  sh:property [
-    sh:path ro:kaartNaam ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:datatype xsd:string ;
-  ] ,
-  [
-    sh:path ro:kaartNummer ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:datatype xsd:string ;
-  ] ,
-  [
-    sh:path ro:symboolCode ;
-    sh:maxCount 1 ;
-    sh:datatype xsd:string ;
-  ]
+  sh:property
+    ro_str:cartografieInfo_kaartNaam ,
+    ro_str:cartografieInfo_kaartNummer ,
+    ro_str:cartografieInfo_symboolCode
 .
 
-### extern plan
+ro_str:cartografieInfo_kaartNaam a sh:PropertyShape ;
+  sh:path ro:kaartNaam ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:datatype xsd:string
+.
+
+ro_str:cartografieInfo_kaartNummer a sh:PropertyShape ;
+  sh:path ro:kaartNummer ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:datatype xsd:string
+.
+
+ro_str:cartografieInfo_symboolCode a sh:PropertyShape ;
+  sh:path ro:symboolCode ;
+  sh:maxCount 1 ;
+  sh:datatype xsd:string
+.
+
+
+#################################################################
+#    Extern plan
+#################################################################
+
 
 ro_str:ExternPlanReferentiePG_SV rdf:type sh:NodeShape ;
   sh:closed true ; # this construct is used to restrict the allowed predicates from the blank node.
@@ -136,41 +153,12 @@ ro_str:ExternPlanReferentiePG_SV rdf:type sh:NodeShape ;
     ro:uitgewerktIn
     ro:gebruiktInformatieUit
     ro:tenGevolgeVan
-    ) #include other properties such as rdf:type of is there a better solution?
-      # it's in a blanknode, there are no other predicates.
-.
-# we could include a sh:SPARQL to make sure all objects are of type ro:PlanologischGebeid?
+    )
+.                               #include other properties such as rdf:type of is there a better solution?
+                                #it's in a blanknode, there are no other predicates.
+                                #we could include a sh:SPARQL to make sure all objects are of type ro:PlanologischGebeid?
+                                #what will happen if we don't have an IRI for a external plan?
 
-#what will happen if we don't have an IRI for a external plan?
-
-#this nodeshape is no longer required for the role predicates point to IRIs, containing a idn and name.
-#ro_str:ExternPlan rdf:type sh:NodeShape ;
-#  sh:property
-#    ro_str:naamExternPlan ,
-#    ro_str:idn # ,
-##    ro_str:rolExternPlan
-#.
-
-ro_str:naamExternPlan rdf:type sh:PropertyShape ;
-  sh:path ro:naam ;
-  sh:minCount 1 ;
-  sh:maxCount 1 ;
-  sh:datatype xsd:string ;
-.
-
-ro_str:idn rdf:type sh:PropertyShape ;
-  sh:path ro:idn ;
-  sh:maxCount 1 ;
-  sh:datatype xsd:string
-.
-
-# roles are now defined as predicates.
-#ro_str:rolExternPlan rdf:type sh:PropertyShape ;
-#  sh:path ro:rolExternPlan ;
-#  sh:minCount 1 ;
-#  sh:maxCount 1 ;
-#  sh:node ro_str:RolExternPlanPG_SV
-#.
 
 ro_str:ExternPlanReferentie_SV rdf:type sh:NodeShape ;
   sh:closed true ;
@@ -181,3 +169,42 @@ ro_str:ExternPlanReferentie_SV rdf:type sh:NodeShape ;
     ro:tenGevolgeVan
     )
 .
+
+ro_str:ExternPlanReferentie_BP rdf:type sh:NodeShape ;
+  sh:closed true ;
+  sh:ignoredProperties (
+    ro:muteert
+    ro:vervangt
+    ro:tenGevolgeVan
+    )
+.
+
+
+#this nodeshape is no longer required for the role predicates point to IRIs, containing a idn and name.
+#ro_str:ExternPlan rdf:type sh:NodeShape ;
+#  sh:property
+#    ro_str:naamExternPlan ,
+#    ro_str:idn ,
+##    ro_str:rolExternPlan
+#.
+
+#ro_str:naamExternPlan rdf:type sh:PropertyShape ;
+#  sh:path ro:naam ;
+#  sh:minCount 1 ;
+#  sh:maxCount 1 ;
+#  sh:datatype xsd:string ;
+#.
+
+#ro_str:idn rdf:type sh:PropertyShape ;
+#  sh:path ro:idn ;
+#  sh:maxCount 1 ;
+#  sh:datatype xsd:string
+#.
+
+# roles are now defined as predicates.
+#ro_str:rolExternPlan rdf:type sh:PropertyShape ;
+#  sh:path ro:rolExternPlan ;
+#  sh:minCount 1 ;
+#  sh:maxCount 1 ;
+#  sh:node ro_str:RolExternPlanPG_SV
+#.


### PR DESCRIPTION
PR for cleaned Common section,

This tackles the following items identified last week (see slack)

1. Connect ro:Plan and ro:Planobject to nen3610 ontology
1b. Add requirement that instances of ro:Plan als be of type void:Dataset in shapes.
2. Create ro:Planobject and add subClass links

5. Convert all ro:Instruments to skos:Concepts, and create skos:Collections for the enumerations
6. Remove uses of ro:RuimtelijkInstrument
7. Add subclasses of ro:Ondergrond as per the Ondergronden enumerations

