### PR TITLE
Besluitgebied_A

### DIFF
--- a/Models/Specific/Besluit/AMVB/model.ttl
+++ b/Models/Specific/Besluit/AMVB/model.ttl
@@ -28,3 +28,45 @@
 @prefix ro_nen3610_beg: <http://data.informatiehuisruimte.nl/nen3610/id/begrip/> .
 @prefix ro_str: <http://data.informatiehuisruimte.nl/def/ro/> .
 @prefix ro_sym: <http://data.informatiehuisruimte.nl/ro/id/symbool/> .
+
+
+
+#################################################################
+#    Algemene Maatregel van Bestuur
+#################################################################
+
+ro:AMVB a owl:Class ;
+  rdfs:subClassOf ro:Besluit ;
+  rdfs:isDefinedBy ro: ;
+  dc:subject ro_beg:AMVB ;
+  rdfs:label "Algemene Maatregel van Bestuur (AMvB)"@nl ;
+  rdfs:comment "Een Algemene Maatregel van Bestuur (AMvB) is een instrument waarmee de Minister regels kan geven omtrent de inhoud van bestemmingsplannen en provinciale inpassingsplannen, daaraan voorafgaande projectbesluiten en beheersverordeningen. Het is daarbij niet altijd noodzakelijk dat er ook een specifiek gebied van het Nederlands grondgebied gedefinieerd wordt. Met betrekking tot dat laatste vallen AMvB’s in twee groepen uiteen: een groep waarin regels gekoppeld zijn aan geografisch geduide gebieden en een groep waarin regels gesteld worden voor het hele land of minder direct aangegeven gebieden."@nl ;
+.
+
+#Jesse: Besluitgebied_A can either be of type AMVB or Regeling. These are sibling classes constrained identically.
+ro:Regeling a owl:Class ;
+  rdfs:subClassOf ro:Besluit ;
+  rdfs:isDefinedBy ro: ;
+  dc:subject ro_beg:Regeling ;
+  rdfs:label "Regeling"@nl
+.
+
+#Jesse: This should be moved up in the file hierarchy..
+ro:normadressant a owl:ObjectProperty ;
+  rdfs:label "normadressant"@nl ;
+  rdfS:isDefinedBy :ro ;
+  rdfs:comment "De instantie, overheid of maatschappelijke partij waar het instrument zich tot richt."@nl
+.
+
+#################################################################
+#    Besluitvlak
+#################################################################
+
+
+ro:Besluitvlak_A a owl:Class ;
+  rdfs:subClassOf ro:Planobject ;
+  rdfs:isDefinedBy ro: ;
+#  dc:subject ro_beg:Besluitvlak_A ;
+  rdfs:label "Besluitvlak_A"@nl ;
+  rdfs:comment "Gebied, of gebieden, waarover het besluit uitspraken doet."@nl ;
+.

--- a/Models/Specific/Besluit/AMVB/shapes.ttl
+++ b/Models/Specific/Besluit/AMVB/shapes.ttl
@@ -1,0 +1,295 @@
+# common @prefix section
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix doco: <http://purl.org/spar/doco/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix gml: <http://www.opengis.net/ont/gml#> .
+@prefix imro: <http://data.imro.com/def/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix nen3610: <http://data.informatiehuisruimte.nl/def/nen3610#> .
+@prefix nen3610_str: <http://data.informatiehuisruimte.nl/def/nen3610/> .
+@prefix ogc: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# prefixes specific to Informatiehuis Ruimte
+@prefix nen3610: <http://data.informatiehuisruimte.nl/def/nen3610#> .
+@prefix pdok_pdok: <http://data.pdok.nl/def/pdok#> .
+@prefix ro: <http://data.informatiehuisruimte.nl/def/ro#> .
+@prefix ro_beg: <http://data.informatiehuisruimte.nl/ro/id/begrip/> .
+@prefix ro_begkr: <http://data.informatiehuisruimte.nl/id/begrippenkader/> .
+@prefix ro_col: <http://data.informatiehuisruimte.nl/id/collectie/> .
+@prefix ro_nen3610_beg: <http://data.informatiehuisruimte.nl/nen3610/id/begrip/> .
+@prefix ro_str: <http://data.informatiehuisruimte.nl/def/ro/> .
+@prefix ro_sym: <http://data.informatiehuisruimte.nl/ro/id/symbool/> .
+
+#################################################################
+#    Besluitgebied_A
+#################################################################
+
+
+#Jesse: This nodeshape constrains both ro:AMVB and ro:Regeling.
+ro_str:Besluitgebied_A a sh:NodeShape ;
+  sh:targetClass ro:AMVB, ro:Regeling ;
+  sh:property
+    ro_str:Besluitgebied_A_hasPart ,
+    ro_str:Besluitgebied_A_spatial ,
+    ro_str:Besluitgebied_A_beleidsmatigVerantwoorlijkeOverheid ,
+    ro_str:Besluitgebied_A_normadressant ,
+    ro_str:Besluitgebied_A_tekstverwijzing ,
+    ro_str:Besluitgebied_A_illustratieverwijzing , #Jesse: common for both Besluitgebied_P and besluitgebied_A, not for besluitgebied_X
+    ro_str:Besluitgebied_A_externPlan ,
+    ro_str:Besluitgebied_A_norm
+.
+
+#Jesse: a single specialisation of Planobject is used, ro:Besluitvlak (the suffixes, _A _P _X are dropped).
+# This class has unique propertyshapes given the related ro:Plan. (due to the sh:node here)
+ro_str:Besluitgebied_A_hasPart a sh:PropertyShape ;
+  sh:path dc:hasPart ;
+  sh:class ro:Besluitvlak ;
+  sh:minCount 1 ;
+  sh:node ro_str:Besluitvlak_A ;
+.
+
+ro_str:Besluitgebied_A_spatial a sh:PropertyShape ;
+  sh:path dc:spatial ;
+# Jesse: these are already inherited
+#  sh:class ro:Plangebied ;
+#  sh:minCount 1 ;
+#  sh:maxCount 1 ;
+  sh:node ro_str:Besluitgebied_A_Plangebied
+.
+
+
+ro_str:Besluitgebied_A_beleidsmatigVerantwoorlijkeOverheid a sh:PropertyShape ;
+  sh:path ro:beleidsmatigVerantwoordelijkeOverheid ;
+  sh:minCount 1 ;
+#  sh:maxCount 1 ; #the gml files concatenates the names of the ministries, resulting in a single instance. Hence, the sh:maxCount 1. However, if we can seperate these again, I think we'll have a more robuust knowledge graph.
+  sh:node ro_str:Overheden_R
+.
+
+ro_str:Besluitgebied_A_normadressant a sh:PropertyShape ;
+  sh:path ro:normadressant ;
+  sh:class skos:Concept ;
+  sh:minCount 1 ;
+  sh:node [
+    sh:property [
+       sh:path [ sh:inversePath skos:member ] ;
+       sh:hasValue ro_col:NormadressantenAMVB ;
+    ]
+  ]
+.
+
+ro_str:Besluitgebied_A_tekstverwijzing a sh:PropertyShape ;
+#  sh:path ro:tekst ;
+  sh:minCount 1 ;
+  sh:maxCount 6 ;
+#Jesse: TODO: qualifiedValueShape (sh:hasValue of the multiple occurences), the IMROPT2012 constraint is in place.
+  sh:xone ( [
+    sh:and (
+      [ sh:path ro:norm ; sh:hasValue ro_beg:IMROPT2012 ; ]
+      [ sh:path ro:tekst ; sh:class ropt:Tekstobject, ro:Tekst ; ] ) ] [
+    sh:and (
+      [ sh:path ro:norm ; sh:not [ sh:hasValue ro_beg:IMROPT ; ] ]
+      [ sh:path ro:tekst ; sh:class ro:Tekst ; sh:not [ sh:class ropt:Tekstobject ]  ]  ) ] ) ;
+  sh:node ro_str:TeksttypeBG_AMB
+.
+
+#Jesse: Move to common/verwijzing/shapes.ttl
+ro_str:TeksttypeBG_AMB a sh:NodeShape ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:in (
+      ro:Besluitdocument
+      ro:Regels
+      ro:Toelichting
+      ro:BijlageBesluitdocument
+      ro:BijlageRegels
+      ro:BijlageToelichting
+    )
+  ]
+.
+
+#Jesse: I am thinking these property shapes could also follow a different structure. e.g. `IllustratieReferentiePG a sh:PropertyShape .` which is used instead of `ro_str:<insertPlan>_illustratieverwijzing`. for a later version perhaps
+ro_str:Besluitgebied_A_illustratieverwijzing a sh:PropertyShape ;
+  sh:path ro:illustratie ;
+  sh:class ro:Illustratie
+.
+
+ro_str:Besluitgebied_A_externPlan a sh:PropertyShape ;
+  sh:path ro:externPlan ;
+  sh:node ro_str:ExternPlanReferentie_AMB
+.
+
+ro_str:ExternPlanReferentie_AMB rdf:type sh:NodeShape ;
+  sh:closed true ;
+  sh:ignoredProperties (
+    ro:muteert
+    ro:vervangt
+    ro:uitTeWerkenIn    #Jesse: IMRO is quite unclear here. Is "in extern plan/besluit uit werken" different from "in extern plan/besluit uit te werken"?
+#    ro:uitgewerktIn
+    ro:gebruiktInformatieUit
+    ro:tenGevolgeVan
+    )
+.
+
+ro_str:Besluitgebied_A_norm a sh:PropertyShape ;
+  sh:path ro:norm ;
+  sh:minCount 2 ;
+  sh:maxCount 3 ;
+  sh:and ( [
+    sh:qualifiedValueShape [
+      sh:hasValue ro_beg:IMRO2012 ;
+    ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:qualifiedMaxCount 1 ;
+    ] [
+    sh:qualifiedValueShape [
+      sh:hasValue ro_beg:PRAMvB2012 ;
+    ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:qualifiedMaxCount 1 ;
+    ] [
+    sh:qualifiedValueShape [
+      sh:hasValue ro_beg:IMROPT2012 ;
+    ] ;
+    sh:qualifiedMaxCount 1 ;
+  ]
+  )
+.
+
+#################################################################
+#    Begrenzing
+#################################################################
+
+ro_str:Besluitgebied_A_Plangebied a sh:NodeShape ;
+  sh:property
+    ro_str:Besluitgebied_A_Plangebied_geometrie ,
+    ro_str:Besluitgebied_A_Plangebied_idealisatie
+.
+
+ro_str:Besluitgebied_A_Plangebied_geometrie a sh:PropertyShape ;
+  sh:path ogc:geometry ;
+#  sh:class ogc:Geometry ; #Jesse: is this required? An instance here would then, for instance, be of type ogc:Geometry AND gml:Surface
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:node ro_str:VlakMultiVlak ;
+.
+
+ro_str:Besluitgebied_A_Plangebied_idealisatie a sh:PropertyShape ;
+  sh:path ro:idealisatie ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:node ro_str:Idealisatie_1 ;
+.
+
+#################################################################
+#    Besluitvlak_A
+#################################################################
+
+
+ro_str:Besluitvlak_A a sh:NodeShape ;
+#  sh:targetClass ro:Besluitvlak_A ; #Jesse: Beluitvlak_A does not exist, the target is 'inherited' from ro_Str:Besluitgebied_A
+  sh:property
+    ro_str:Besluitvlak_A_thema ,
+    ro_str:Besluitvlak_A_tekst ,
+    ro_str:Besluitvlak_A_illustratie ,
+    ro_str:Besluitvlak_A_cartografie , #Jesse: my concern here is that I am not sure whether these are attributes of the specialization of ro:Illustratie, ro:Kaart. Hence, I put this in a blank node.
+    ro_str:Besluitvlak_A_begrenzing ,
+    ro_str:Besluitvlak_A_hasPart
+.
+
+ro_str:Besluitvlak_A_thema a sh:PropertyShape ;
+  sh:path ro:thema ;
+  sh:datatype xsd:string ;
+  sh:nodeKind sh:Literal ;
+  sh:minCount 1
+.
+
+ro_str:Besluitvlak_A_tekst a sh:PropertyShape ;
+  sh:path ro:tekst ;
+  sh:minCount 1 ;
+  #Jesse: TODO: qualifiedValueShape (sh:hasValue of the multiple occurences), the IMROPT2012 constraint is in place.
+  sh:xone ( [
+    sh:and (
+      [ sh:path ro:norm ; sh:hasValue ro_beg:IMROPT2012 ; ]
+      [ sh:path ro:tekst ; sh:class ropt:Tekstobject, ro:Tekst ; ] ) ] [
+    sh:and (
+      [ sh:path ro:norm ; sh:not [ sh:hasValue ro_beg:IMROPT ; ] ]
+      [ sh:path ro:tekst ; sh:class ro:Tekst ; sh:not [ sh:class ropt:Tekstobject ]  ]  ) ] ) ;
+  sh:node ro_str:Teksttype_AMB
+.
+
+ro_str:Teksttype_AMB a sh:NodeShape ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:in (
+      ro:Besluittekst
+      ro:Regels
+      ro:Toelichting
+      ro:BijlageBesluittekst
+      ro:BijlageRegels
+      ro:BijlageToelichting
+    )
+  ]
+.
+
+ro_str:Besluitvlak_A_illustratie a sh:PropertyShape ;
+  sh:path ro:illustratie ;
+  sh:class ro:Illustratie ;
+  sh:node ro_str:Illustratie_legendaNaam
+.
+
+ro_str:Besluitvlak_A_cartografie a sh:PropertyShape ;
+  sh:path ro:cartografie ;
+  sh:node ro_str:cartografieInfo
+.
+
+ro_str:Besluitvlak_A_begrenzing a sh:PropertyShape ;
+  sh:path ro:begrenzing ;
+  sh:class ogc:Geometry ;
+  sh:minCount 1 ;
+  sh:node ro_str:Besluitgebied_A_Geometry
+.
+
+ro_str:Besluitvlak_A_Geometry a sh:NodeShape ;
+  sh:property
+    ro_str:Besluitvlak_A_Geometry_geometry ,
+    ro_str:Besluitvlak_A_Geometry_idealisatie
+.
+
+ro_str:Besluitvlak_A_Geometrie_geometry a sh:PropertyShape ;
+  sh:path ogc:geometry ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:node ro_str:PuntLijnVlakMulti
+.
+
+ro_str:Besluitvlak_A_Geometrie_idealisatie a sh:PropertyShape ;
+  sh:path ro:idealisatie ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:node ro_str:Idealisatie_2
+.
+
+ro_str:Besluitvlak_A_hasPart a sh:PropertyShape ;
+  sh:path dc:hasPart ;
+  sh:class ro:Besluitvlak ;
+  sh:node
+    ro_str:Besluitvlak_A ,
+    ro_str:Besluitsubvlak_A_isPartOf
+.
+
+ro_str:Besluitsubvlak_A_isPartOf a sh:NodeShape ;
+  sh:property [
+    sh:path dc:isPartOf ;
+    sh:class ro:AMVB, ro:Regeling ;
+    sh:minCount 1 ; #Jesse: IMRO defines a min cardinality of 0, However, I don't think a part can exist without its whole.
+  ]
+.


### PR DESCRIPTION
Besluitgebied_A is either a ro:AMVB or ro:Regeling.
It has a ro:Planobject; ro:Besluitvlak.
ro:Besluitvlak is constrained according to the respective plan type.

ro:Besluitvlak_A and Besluitgebied_A contain all the properties not applicable to each specialisation of ro:Besluit.

It does not use dc:subject instead of ro:thema.
ro:kaart is not (yet) used as it is not clear what its relation is with ro:Illustratie

The model uses IMROPT for text references only when the norm attribute has value IMROPT2012.

Further comments in the files..

The two files (shapes.ttl, model.ttl) contain some elements that ought to be in a different folder, but that is for later..
