### PR TITLE
Cartografie

### DIFF
--- a/Models/Specific/Besluit/begrip.ttl
+++ b/Models/Specific/Besluit/begrip.ttl
@@ -338,4 +338,3 @@ ro_col:NormadressantenOverigGebiedsgerichtBesluit a skos:Collection;
     ro_beg:Rijksbestuursorganen,
     ro_beg:NietNaderAangeduid;
 .
-

--- a/Models/Specific/Bestemmingsplan/model.ttl
+++ b/Models/Specific/Bestemmingsplan/model.ttl
@@ -173,7 +173,7 @@ ro:Maatvoering a owl:Class ;
 .
 
 ###############
-### Symbool
+### Symboolplaatsing
 ###############
 
 #symboolPlaatsing points to a blank node containing a ro:symbol and ro:positie
@@ -182,134 +182,6 @@ ro:symboolPlaatsing a owl:AnnotationProperty ;
   rdfs:isDefinedBy :ro ;
   rdfs:domain ro:Maatvoering ;
 .
-
-ro:symbool a owl:AnnotationProperty ; #or should this be an objectproperty?
-  rdfs:label "symbool"@nl ;
-  rdfs:isDefinedBy :ro ;
-  rdfs:range ro:Symbool ;
-.
-
-ro:Symbool a owl:Class ;
-  rdfs:label "Symbool"@nl ;
-  rdfs:isDefinedBy :ro ;
-.
-
-ro:code a owl:DatatypeProperty ;
-  rdfs:label "code"@nl ;
-  rdfs:isDefinedBy :ro ;
-.
-
-ro_sym:s100 a ro:Symbool, owl:NamedIndividual ; ro:code "s100" .
-ro_sym:s101 a ro:Symbool, owl:NamedIndividual ; ro:code "s101" .
-ro_sym:s102 a ro:Symbool, owl:NamedIndividual ; ro:code "s102" .
-ro_sym:s103 a ro:Symbool, owl:NamedIndividual ; ro:code "s103" .
-ro_sym:s104 a ro:Symbool, owl:NamedIndividual ; ro:code "s104" .
-ro_sym:s105 a ro:Symbool, owl:NamedIndividual ; ro:code "s105" .
-ro_sym:s106 a ro:Symbool, owl:NamedIndividual ; ro:code "s106" .
-ro_sym:s107 a ro:Symbool, owl:NamedIndividual ; ro:code "s107" .
-ro_sym:s108 a ro:Symbool, owl:NamedIndividual ; ro:code "s108" .
-ro_sym:s109 a ro:Symbool, owl:NamedIndividual ; ro:code "s109" .
-ro_sym:s110 a ro:Symbool, owl:NamedIndividual ; ro:code "s110" .
-ro_sym:s111 a ro:Symbool, owl:NamedIndividual ; ro:code "s111" .
-ro_sym:s112 a ro:Symbool, owl:NamedIndividual ; ro:code "s112" .
-ro_sym:s113 a ro:Symbool, owl:NamedIndividual ; ro:code "s113" .
-ro_sym:s114 a ro:Symbool, owl:NamedIndividual ; ro:code "s114" .
-ro_sym:s115 a ro:Symbool, owl:NamedIndividual ; ro:code "s115" .
-ro_sym:s116 a ro:Symbool, owl:NamedIndividual ; ro:code "s116" .
-ro_sym:s117 a ro:Symbool, owl:NamedIndividual ; ro:code "s117" .
-ro_sym:s118 a ro:Symbool, owl:NamedIndividual ; ro:code "s118" .
-ro_sym:s119 a ro:Symbool, owl:NamedIndividual ; ro:code "s119" .
-ro_sym:s120 a ro:Symbool, owl:NamedIndividual ; ro:code "s120" .
-ro_sym:s121 a ro:Symbool, owl:NamedIndividual ; ro:code "s121" .
-ro_sym:s122 a ro:Symbool, owl:NamedIndividual ; ro:code "s122" .
-ro_sym:s123 a ro:Symbool, owl:NamedIndividual ; ro:code "s123" .
-ro_sym:s124 a ro:Symbool, owl:NamedIndividual ; ro:code "s124" .
-ro_sym:s125 a ro:Symbool, owl:NamedIndividual ; ro:code "s125" .
-ro_sym:s126 a ro:Symbool, owl:NamedIndividual ; ro:code "s126" .
-ro_sym:s127 a ro:Symbool, owl:NamedIndividual ; ro:code "s127" .
-ro_sym:s128a a ro:Symbool, owl:NamedIndividual ; ro:code "s128a" .
-ro_sym:s128b a ro:Symbool, owl:NamedIndividual ; ro:code "s128b" .
-ro_sym:s128c a ro:Symbool, owl:NamedIndividual ; ro:code "s128c" .
-ro_sym:s128d a ro:Symbool, owl:NamedIndividual ; ro:code "s128d" .
-ro_sym:s128e a ro:Symbool, owl:NamedIndividual ; ro:code "s128e" .
-ro_sym:s128f a ro:Symbool, owl:NamedIndividual ; ro:code "s128f" .
-ro_sym:s128g a ro:Symbool, owl:NamedIndividual ; ro:code "s128g" .
-ro_sym:s128h a ro:Symbool, owl:NamedIndividual ; ro:code "s128h" .
-ro_sym:s128i a ro:Symbool, owl:NamedIndividual ; ro:code "s128i" .
-ro_sym:s128j a ro:Symbool, owl:NamedIndividual ; ro:code "s128j" .
-ro_sym:s128k a ro:Symbool, owl:NamedIndividual ; ro:code "s128k" .
-ro_sym:s128l a ro:Symbool, owl:NamedIndividual ; ro:code "s128l" .
-ro_sym:s128m a ro:Symbool, owl:NamedIndividual ; ro:code "s128m" .
-ro_sym:s128n a ro:Symbool, owl:NamedIndividual ; ro:code "s128n" .
-ro_sym:s128o a ro:Symbool, owl:NamedIndividual ; ro:code "s128o" .
-ro_sym:s128p a ro:Symbool, owl:NamedIndividual ; ro:code "s128p" .
-ro_sym:s128q a ro:Symbool, owl:NamedIndividual ; ro:code "s128q" .
-ro_sym:s128r a ro:Symbool, owl:NamedIndividual ; ro:code "s128r" .
-ro_sym:s128s a ro:Symbool, owl:NamedIndividual ; ro:code "s128s" .
-ro_sym:s128t a ro:Symbool, owl:NamedIndividual ; ro:code "s128t" .
-ro_sym:s128u a ro:Symbool, owl:NamedIndividual ; ro:code "s128u" .
-ro_sym:s128v a ro:Symbool, owl:NamedIndividual ; ro:code "s128v" .
-ro_sym:s128w a ro:Symbool, owl:NamedIndividual ; ro:code "s128w" .
-ro_sym:s128x a ro:Symbool, owl:NamedIndividual ; ro:code "s128x" .
-ro_sym:s128y a ro:Symbool, owl:NamedIndividual ; ro:code "s128y" .
-ro_sym:s128z a ro:Symbool, owl:NamedIndividual ; ro:code "s128z" .
-ro_sym:s128aa a ro:Symbool, owl:NamedIndividual ; ro:code "s128aa" .
-ro_sym:s128ab a ro:Symbool, owl:NamedIndividual ; ro:code "s128ab" .
-ro_sym:s128ac a ro:Symbool, owl:NamedIndividual ; ro:code "s128ac" .
-ro_sym:s128ad a ro:Symbool, owl:NamedIndividual ; ro:code "s128ad" .
-ro_sym:s128ae a ro:Symbool, owl:NamedIndividual ; ro:code "s128ae" .
-ro_sym:s128af a ro:Symbool, owl:NamedIndividual ; ro:code "s128af" .
-ro_sym:s129a a ro:Symbool, owl:NamedIndividual ; ro:code "s129a" .
-ro_sym:s129b a ro:Symbool, owl:NamedIndividual ; ro:code "s129b" .
-ro_sym:s129c a ro:Symbool, owl:NamedIndividual ; ro:code "s129c" .
-ro_sym:s129d a ro:Symbool, owl:NamedIndividual ; ro:code "s129d" .
-ro_sym:s129e a ro:Symbool, owl:NamedIndividual ; ro:code "s129e" .
-ro_sym:s129f a ro:Symbool, owl:NamedIndividual ; ro:code "s129f" .
-ro_sym:s129g a ro:Symbool, owl:NamedIndividual ; ro:code "s129g" .
-ro_sym:s129h a ro:Symbool, owl:NamedIndividual ; ro:code "s129h" .
-ro_sym:s129i a ro:Symbool, owl:NamedIndividual ; ro:code "s129i" .
-ro_sym:s129j a ro:Symbool, owl:NamedIndividual ; ro:code "s129j" .
-ro_sym:s129k a ro:Symbool, owl:NamedIndividual ; ro:code "s129k" .
-ro_sym:s129l a ro:Symbool, owl:NamedIndividual ; ro:code "s129l" .
-ro_sym:s129m a ro:Symbool, owl:NamedIndividual ; ro:code "s129m" .
-ro_sym:s129n a ro:Symbool, owl:NamedIndividual ; ro:code "s129n" .
-ro_sym:s129o a ro:Symbool, owl:NamedIndividual ; ro:code "s129o" .
-ro_sym:s129p a ro:Symbool, owl:NamedIndividual ; ro:code "s129p" .
-ro_sym:s129q a ro:Symbool, owl:NamedIndividual ; ro:code "s129q" .
-ro_sym:s129r a ro:Symbool, owl:NamedIndividual ; ro:code "s129r" .
-ro_sym:s129s a ro:Symbool, owl:NamedIndividual ; ro:code "s129s" .
-ro_sym:s129t a ro:Symbool, owl:NamedIndividual ; ro:code "s129t" .
-ro_sym:s129u a ro:Symbool, owl:NamedIndividual ; ro:code "s129u" .
-ro_sym:s129v a ro:Symbool, owl:NamedIndividual ; ro:code "s129v" .
-ro_sym:s129w a ro:Symbool, owl:NamedIndividual ; ro:code "s129w" .
-ro_sym:s129x a ro:Symbool, owl:NamedIndividual ; ro:code "s129x" .
-ro_sym:s129y a ro:Symbool, owl:NamedIndividual ; ro:code "s129y" .
-ro_sym:s129z a ro:Symbool, owl:NamedIndividual ; ro:code "s129z" .
-ro_sym:s129aa a ro:Symbool, owl:NamedIndividual ; ro:code "s129aa" .
-ro_sym:s129ab a ro:Symbool, owl:NamedIndividual ; ro:code "s129ab" .
-ro_sym:s130a a ro:Symbool, owl:NamedIndividual ; ro:code "s130a" .
-ro_sym:s130b a ro:Symbool, owl:NamedIndividual ; ro:code "s130b" .
-ro_sym:s130c a ro:Symbool, owl:NamedIndividual ; ro:code "s130c" .
-ro_sym:s130d a ro:Symbool, owl:NamedIndividual ; ro:code "s130d" .
-ro_sym:s130e a ro:Symbool, owl:NamedIndividual ; ro:code "s130e" .
-ro_sym:s130f a ro:Symbool, owl:NamedIndividual ; ro:code "s130f" .
-ro_sym:s130g a ro:Symbool, owl:NamedIndividual ; ro:code "s130g" .
-ro_sym:s130h a ro:Symbool, owl:NamedIndividual ; ro:code "s130h" .
-ro_sym:s130i a ro:Symbool, owl:NamedIndividual ; ro:code "s130i" .
-ro_sym:s130j a ro:Symbool, owl:NamedIndividual ; ro:code "s130j" .
-ro_sym:s130k a ro:Symbool, owl:NamedIndividual ; ro:code "s130k" .
-ro_sym:s130l a ro:Symbool, owl:NamedIndividual ; ro:code "s130l" .
-ro_sym:s130m a ro:Symbool, owl:NamedIndividual ; ro:code "s130m" .
-ro_sym:s130n a ro:Symbool, owl:NamedIndividual ; ro:code "s130n" .
-ro_sym:s130o a ro:Symbool, owl:NamedIndividual ; ro:code "s130o" .
-ro_sym:s130p a ro:Symbool, owl:NamedIndividual ; ro:code "s130p" .
-ro_sym:s130q a ro:Symbool, owl:NamedIndividual ; ro:code "s130q" .
-ro_sym:s130r a ro:Symbool, owl:NamedIndividual ; ro:code "s130r" .
-ro_sym:s130s a ro:Symbool, owl:NamedIndividual ; ro:code "s130s" .
-ro_sym:s130t a ro:Symbool, owl:NamedIndividual ; ro:code "s130t" .
-ro_sym:s130u a ro:Symbool, owl:NamedIndividual ; ro:code "s130u" .
-ro_sym:s130v a ro:Symbool, owl:NamedIndividual ; ro:code "s130v" .
-ro_sym:s130w a ro:Symbool, owl:NamedIndividual ; ro:code "s130w" .
 
 ###############
 ### Maatvoering / Omvang

--- a/Models/Specific/Bestemmingsplan/shapes.ttl
+++ b/Models/Specific/Bestemmingsplan/shapes.ttl
@@ -545,33 +545,6 @@ ro_str:Maatvoering_aanduiding a sh:PropertyShape ;
   sh:maxCount 1
 .
 
-
-#################################################################
-#    Symbool
-#################################################################
-
-ro_str:Symbool a sh:NodeShape ;
-  sh:targetClass ro:Symbool ;
-  sh:property
-    ro_str:Symbool_code ,
-    ro_str:Symbool_positie ;
-.
-
-ro_str:Symbool_code a sh:PropertyShape;
-  sh:path ro:code ;
-  sh:mincount 1 ;
-  sh:maxCount 1 ;
-  sh:nodeKind sh:Literal ;
-  sh:datatype xsd:String ;
-.
-
-ro_str:Symbool_positie a sh:PropertyShape ;
-  sh:path ro:positie ;
-  sh:class sh:Labelpositie ;
-  sh:minCount 1
-.
-
-
 #################################################################
 #    Figuur
 #################################################################

--- a/Models/Specific/Structuurvisie/Structuurvisie_P/shapes.ttl
+++ b/Models/Specific/Structuurvisie/Structuurvisie_P/shapes.ttl
@@ -204,7 +204,7 @@ ro_str:Structuurvisieverklaring_P rdf:type sh:NodeShape ;
     ro_str:Structuurvisiecomplex_thema , #copied
     ro_str:Structuurvisieverklaring_P_tekstVerwijzing ,
     ro_str:Structuurvisieverklaring_illustratieverwijzing ,
-    ro_str:Structuurvisiegebied_cartografie , #copied
+    ro_str:Structuurvisiegebied_isCartografischOnderdeelVan , #copied
     ro_str:Structuurvisieverklaring_isPartOf
 .
 

--- a/Models/Specific/Structuurvisie/shapes.ttl
+++ b/Models/Specific/Structuurvisie/shapes.ttl
@@ -144,7 +144,7 @@ ro_str:Structuurvisiegebied a sh:NodeShape ;
       ro_str:Structuurvisiegebied_thema ,
       ro_str:Structuurvisiegebied_illustratieVerwijzing , #partially common
       ro_str:Structuurvisiegebied_externPlan ,
-      ro_str:Structuurvisiegebied_cartografie , #TODO: add hoofdkaart == nummer 1
+      ro_str:Structuurvisiegebied_isCartografischOnderdeelVan , #TODO: add hoofdkaart == nummer 1
       ro_str:Structuurvisiegebied_begrenzing ,
       ro_str:Structuurvisiegebied_isPartOf
 .
@@ -169,9 +169,9 @@ ro_str:Structuurvisiegebied_externPlan a sh:PropertyShape ;
   sh:node ro_str:ExternPlanReferentie_SV ;
 .
 
-ro_str:Structuurvisiegebied_cartografie a sh:PropertyShape ; #perhaps applicable for all planobjects?
-  sh:path ro:cartografie ;
-  sh:node ro_str:cartografieInfo ;
+ro_str:Structuurvisiegebied_isCartografischOnderdeelVan a sh:PropertyShape ; #perhaps applicable for all planobjects?
+  sh:path ro:isCartografischOnderdeelVan ;
+  sh:node ro_str:Verbeeldingskaart ;
 .
 
 ro_str:Structuurvisiegebied_begrenzing rdf:type sh:PropertyShape ;
@@ -216,7 +216,7 @@ ro_str:Structuurvisiecomplex a sh:NodeShape ;
     ro_str:Structuurvisiecomplex_thema ,
     ro_str:Structuurvisiegebied_illustratieVerwijzing ,  #copied same as ro:structuurvisiegebied_illustratieVerwijzing
     ro_str:Structuurvisiegebied_externPlan , #copied same as ro_str:Structuurvisiegebied_externPlan
-    ro_str:Structuurvisiegebied_cartografie , #copied same as ro_str:Structuurvisiegebied_cartografie
+    ro_str:Structuurvisiegebied_isCartografischOnderdeelVan , #copied same as ro_str:Structuurvisiegebied_isCartografischOnderdeelVan
     ro_str:Structuurvisiegebied_begrenzing ,  #copied same as ro:structuurvisiegebied_illustratieVerwijzing
     ro_str:Structuurvisiecomplex_hasPart ,
     ro_str:Structuurvisiegebied_isPartOf #copied same as ro:structuurvisiegebied_isPartOf

--- a/Models/common/begrip.ttl
+++ b/Models/common/begrip.ttl
@@ -1120,7 +1120,7 @@ ro_beg:MinimumVerticaleBouwdiepte_m_Omvang a skos:Concept ;
 ro_beg:Structuurvisie a skos:Concept ;
 	rdfs:label "Structuurvisie"@nl ;
 	skos:prefLabel "Structuurvisie"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Plan ;
+	skos-thes:broaderGeneric ro_beg:Plan ;
 	skos:definition "Gebied, of gebieden, binnen de grenzen van een structuurvise."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisie"
@@ -1129,7 +1129,7 @@ ro_beg:Structuurvisie a skos:Concept ;
 ro_beg:Structuurvisiegebied a skos:Concept ;
 	rdfs:label "Structuurvisiegebied"@nl ;
 	skos:prefLabel "Structuurvisiegebied"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Planobject ;
+	skos-thes:broaderGeneric ro_beg:Planobject ;
 	skos:definition "Een gebied waarop één of meerdere beleidsuitspraken in het kader van een structuurvisie betrekking hebben."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiegebied"
@@ -1138,7 +1138,7 @@ ro_beg:Structuurvisiegebied a skos:Concept ;
 ro_beg:Structuurvisiecomplex a skos:Concept ;
 	rdfs:label "Structuurvisiecomplex"@nl ;
 	skos:prefLabel "Structuurvisiecomplex"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Planobject ;
+	skos-thes:broaderGeneric ro_beg:Planobject ;
 	skos:definition "Een samenstelling van objecten Structuurvisiegebied en of andere complexen binnen één structuurvisie, waarop één of meerdere beleidsuitspraken betrekking hebben en waarbij op het niveau van de samenstellende delen (gebieden en/of andere complexen) verschillende specifieke beleidsuitspraken gedaan moeten worden."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiecomplex"
@@ -1151,7 +1151,7 @@ ro_beg:Structuurvisiecomplex a skos:Concept ;
 ro_beg:Structuurvisie_R a skos:Concept ;
 	rdfs:label "Structuurvisie_R"@nl ;
 	skos:prefLabel "Structuurvisie_R"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisie ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisie ;
 #	skos:definition "Gebied, of gebieden, binnen de grenzen van een Rijksstructuurvise."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "Rijks structuurvisie"
@@ -1160,7 +1160,7 @@ ro_beg:Structuurvisie_R a skos:Concept ;
 ro_beg:Structuurvisiegebied_R a skos:Concept ;
 	rdfs:label "Structuurvisiegebied_R"@nl ;
 	skos:prefLabel "Structuurvisiegebied_R"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisiegebied ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisiegebied ;
 	skos:definition "Een gebied waarop één of meerdere beleidsuitspraken in het kader van een Rijksstructuurvisie betrekking hebben."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiegebied_R"
@@ -1170,7 +1170,7 @@ ro_beg:Structuurvisiegebied_R a skos:Concept ;
 ro_beg:Structuurvisiecomplex_R a skos:Concept ;
 	rdfs:label "Structuurvisiecomplex_R"@nl ;
 	skos:prefLabel "Structuurvisiecomplex_R"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisiecomplex ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisiecomplex ;
 	skos:definition "Een samenstelling van objecten Structuurvisiegebied en of andere complexen binnen één structuurvisie, waarop één of meerdere beleidsuitspraken betrekking hebben en waarbij op het niveau van de samenstellende delen (gebieden en/of andere complexen) verschillende specifieke beleidsuitspraken gedaan moeten worden."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiecomplex_R"
@@ -1183,7 +1183,7 @@ ro_beg:Structuurvisiecomplex_R a skos:Concept ;
 ro_beg:Structuurvisie_P a skos:Concept ;
 	rdfs:label "Structuurvisie_P"@nl ;
 	skos:prefLabel "Structuurvisie_P"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisie ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisie ;
 #	skos:definition "Gebied, of gebieden, binnen de grenzen van een provinciale structuurvise."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "Provinciale structuurvisie"
@@ -1192,7 +1192,7 @@ ro_beg:Structuurvisie_P a skos:Concept ;
 ro_beg:Structuurvisiegebied_P a skos:Concept ;
 	rdfs:label "Structuurvisiegebied_P"@nl ;
 	skos:prefLabel "Structuurvisiegebied_P"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisiegebied ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisiegebied ;
 	skos:definition "Een gebied waarop één of meerdere beleidsuitspraken in het kader van een provinciale structuurvisie betrekking hebben."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiegebied_P"
@@ -1202,7 +1202,7 @@ ro_beg:Structuurvisiegebied_P a skos:Concept ;
 ro_beg:Structuurvisiecomplex_P a skos:Concept ;
 	rdfs:label "Structuurvisiecomplex_P"@nl ;
 	skos:prefLabel "Structuurvisiecomplex_P"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisiecomplex ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisiecomplex ;
 	skos:definition "Een samenstelling van objecten Structuurvisiegebied en of andere complexen binnen één structuurvisie, waarop één of meerdere beleidsuitspraken betrekking hebben en waarbij op het niveau van de samenstellende delen (gebieden en/of andere complexen) verschillende specifieke beleidsuitspraken gedaan moeten worden."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiecomplex_P"
@@ -1211,7 +1211,7 @@ ro_beg:Structuurvisiecomplex_P a skos:Concept ;
 ro_beg:Structuurvisieverklaring_P a skos:Concept ;
 	rdfs:label "Structuurvisieverklaring_P"@nl ;
 	skos:prefLabel "Structuurvisieverklaring_P"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Planobject ;
+	skos-thes:broaderGeneric ro_beg:Planobject ;
 	skos:definition "Ruimtelijke eenheid waaraan geen beleid gekoppeld is maar die wel in de plankaart als toelichting of nadere verklaring is opgenomen."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisieverklaring_P"
@@ -1225,7 +1225,7 @@ ro_beg:Structuurvisieverklaring_P a skos:Concept ;
 ro_beg:Structuurvisie_G a skos:Concept ;
 	rdfs:label "Structuurvisie_G"@nl ;
 	skos:prefLabel "Structuurvisie_G"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisie ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisie ;
 #	skos:definition "Gebied, of gebieden, binnen de grenzen van een gemeentelijke structuurvise."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "Gemeentelijke structuurvisie"
@@ -1234,7 +1234,7 @@ ro_beg:Structuurvisie_G a skos:Concept ;
 ro_beg:Structuurvisiegebied_G a skos:Concept ;
 	rdfs:label "Structuurvisiegebied_G"@nl ;
 	skos:prefLabel "Structuurvisiegebied_G"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisiegebied ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisiegebied ;
 	skos:definition "Een gebied waarop één of meerdere beleidsuitspraken in het kader van een gemeentelijke structuurvisie betrekking hebben."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiegebied_G"
@@ -1244,7 +1244,7 @@ ro_beg:Structuurvisiegebied_G a skos:Concept ;
 ro_beg:Structuurvisiecomplex_G a skos:Concept ;
 	rdfs:label "Structuurvisiecomplex_G"@nl ;
 	skos:prefLabel "Structuurvisiecomplex_G"@nl ;
-	skos-thes:broaderGeneric: ro_beg:Structuurvisiecomplex ;
+	skos-thes:broaderGeneric ro_beg:Structuurvisiecomplex ;
 	skos:definition "Een samenstelling van objecten Structuurvisiegebied en of andere complexen binnen één structuurvisie, waarop één of meerdere beleidsuitspraken betrekking hebben en waarbij op het niveau van de samenstellende delen (gebieden en/of andere complexen) verschillende specifieke beleidsuitspraken gedaan moeten worden."@nl ;
 	skos:inScheme ro_begkr:ro ;
 	skos:notation "structuurvisiecomplex_G"

--- a/Models/common/model.ttl
+++ b/Models/common/model.ttl
@@ -177,3 +177,157 @@ ro:instrument a owl:ObjectProperty ;
   rdfs:label "instrument"@nl ;
   rdfs:range ro_beg:Instrument ;
 .
+
+###############
+### cartografie
+###############
+
+ro:isCartografischOnderdeelVan a owl:ObjectProperty ;
+  rdfs:label "is cartografisch onderdeel van"@nl ;
+  rdfs:domain ro:Planobject ;
+  rdfs:range ro:Verbeeldingskaart ;
+  rdfs:isDefinedBy :ro ;
+.
+
+ro:Verbeeldingskaart a owl:Class ;
+  rdfs:label "Verbeeldingskaart"@nl ;
+  rdfs:isDefinedBy :ro ;
+.
+
+ro:kaartnummer a owl:DatatypeProperty ;
+  rdfs:label "kaartnummer" ;
+  rdfs:domain ro:Verbeeldingskaart ;
+  rdfs:isDefinedBy :ro ;
+.
+
+###############
+### Symbool
+###############
+
+ro:symbool a owl:AnnotationProperty ; #or should this be an objectproperty?
+  rdfs:label "symbool"@nl ;
+  rdfs:isDefinedBy :ro ;
+  rdfs:range ro:Symbool ;
+.
+
+ro:Symbool a owl:Class ;
+  rdfs:label "Symbool"@nl ;
+  rdfs:isDefinedBy :ro ;
+.
+
+ro:code a owl:DatatypeProperty ;
+  rdfs:label "code"@nl ;
+  rdfs:isDefinedBy :ro ;
+.
+
+ro_sym:s100 a ro:Symbool, owl:NamedIndividual ; ro:code "s100" .
+ro_sym:s101 a ro:Symbool, owl:NamedIndividual ; ro:code "s101" .
+ro_sym:s102 a ro:Symbool, owl:NamedIndividual ; ro:code "s102" .
+ro_sym:s103 a ro:Symbool, owl:NamedIndividual ; ro:code "s103" .
+ro_sym:s104 a ro:Symbool, owl:NamedIndividual ; ro:code "s104" .
+ro_sym:s105 a ro:Symbool, owl:NamedIndividual ; ro:code "s105" .
+ro_sym:s106 a ro:Symbool, owl:NamedIndividual ; ro:code "s106" .
+ro_sym:s107 a ro:Symbool, owl:NamedIndividual ; ro:code "s107" .
+ro_sym:s108 a ro:Symbool, owl:NamedIndividual ; ro:code "s108" .
+ro_sym:s109 a ro:Symbool, owl:NamedIndividual ; ro:code "s109" .
+ro_sym:s110 a ro:Symbool, owl:NamedIndividual ; ro:code "s110" .
+ro_sym:s111 a ro:Symbool, owl:NamedIndividual ; ro:code "s111" .
+ro_sym:s112 a ro:Symbool, owl:NamedIndividual ; ro:code "s112" .
+ro_sym:s113 a ro:Symbool, owl:NamedIndividual ; ro:code "s113" .
+ro_sym:s114 a ro:Symbool, owl:NamedIndividual ; ro:code "s114" .
+ro_sym:s115 a ro:Symbool, owl:NamedIndividual ; ro:code "s115" .
+ro_sym:s116 a ro:Symbool, owl:NamedIndividual ; ro:code "s116" .
+ro_sym:s117 a ro:Symbool, owl:NamedIndividual ; ro:code "s117" .
+ro_sym:s118 a ro:Symbool, owl:NamedIndividual ; ro:code "s118" .
+ro_sym:s119 a ro:Symbool, owl:NamedIndividual ; ro:code "s119" .
+ro_sym:s120 a ro:Symbool, owl:NamedIndividual ; ro:code "s120" .
+ro_sym:s121 a ro:Symbool, owl:NamedIndividual ; ro:code "s121" .
+ro_sym:s122 a ro:Symbool, owl:NamedIndividual ; ro:code "s122" .
+ro_sym:s123 a ro:Symbool, owl:NamedIndividual ; ro:code "s123" .
+ro_sym:s124 a ro:Symbool, owl:NamedIndividual ; ro:code "s124" .
+ro_sym:s125 a ro:Symbool, owl:NamedIndividual ; ro:code "s125" .
+ro_sym:s126 a ro:Symbool, owl:NamedIndividual ; ro:code "s126" .
+ro_sym:s127 a ro:Symbool, owl:NamedIndividual ; ro:code "s127" .
+ro_sym:s128a a ro:Symbool, owl:NamedIndividual ; ro:code "s128a" .
+ro_sym:s128b a ro:Symbool, owl:NamedIndividual ; ro:code "s128b" .
+ro_sym:s128c a ro:Symbool, owl:NamedIndividual ; ro:code "s128c" .
+ro_sym:s128d a ro:Symbool, owl:NamedIndividual ; ro:code "s128d" .
+ro_sym:s128e a ro:Symbool, owl:NamedIndividual ; ro:code "s128e" .
+ro_sym:s128f a ro:Symbool, owl:NamedIndividual ; ro:code "s128f" .
+ro_sym:s128g a ro:Symbool, owl:NamedIndividual ; ro:code "s128g" .
+ro_sym:s128h a ro:Symbool, owl:NamedIndividual ; ro:code "s128h" .
+ro_sym:s128i a ro:Symbool, owl:NamedIndividual ; ro:code "s128i" .
+ro_sym:s128j a ro:Symbool, owl:NamedIndividual ; ro:code "s128j" .
+ro_sym:s128k a ro:Symbool, owl:NamedIndividual ; ro:code "s128k" .
+ro_sym:s128l a ro:Symbool, owl:NamedIndividual ; ro:code "s128l" .
+ro_sym:s128m a ro:Symbool, owl:NamedIndividual ; ro:code "s128m" .
+ro_sym:s128n a ro:Symbool, owl:NamedIndividual ; ro:code "s128n" .
+ro_sym:s128o a ro:Symbool, owl:NamedIndividual ; ro:code "s128o" .
+ro_sym:s128p a ro:Symbool, owl:NamedIndividual ; ro:code "s128p" .
+ro_sym:s128q a ro:Symbool, owl:NamedIndividual ; ro:code "s128q" .
+ro_sym:s128r a ro:Symbool, owl:NamedIndividual ; ro:code "s128r" .
+ro_sym:s128s a ro:Symbool, owl:NamedIndividual ; ro:code "s128s" .
+ro_sym:s128t a ro:Symbool, owl:NamedIndividual ; ro:code "s128t" .
+ro_sym:s128u a ro:Symbool, owl:NamedIndividual ; ro:code "s128u" .
+ro_sym:s128v a ro:Symbool, owl:NamedIndividual ; ro:code "s128v" .
+ro_sym:s128w a ro:Symbool, owl:NamedIndividual ; ro:code "s128w" .
+ro_sym:s128x a ro:Symbool, owl:NamedIndividual ; ro:code "s128x" .
+ro_sym:s128y a ro:Symbool, owl:NamedIndividual ; ro:code "s128y" .
+ro_sym:s128z a ro:Symbool, owl:NamedIndividual ; ro:code "s128z" .
+ro_sym:s128aa a ro:Symbool, owl:NamedIndividual ; ro:code "s128aa" .
+ro_sym:s128ab a ro:Symbool, owl:NamedIndividual ; ro:code "s128ab" .
+ro_sym:s128ac a ro:Symbool, owl:NamedIndividual ; ro:code "s128ac" .
+ro_sym:s128ad a ro:Symbool, owl:NamedIndividual ; ro:code "s128ad" .
+ro_sym:s128ae a ro:Symbool, owl:NamedIndividual ; ro:code "s128ae" .
+ro_sym:s128af a ro:Symbool, owl:NamedIndividual ; ro:code "s128af" .
+ro_sym:s129a a ro:Symbool, owl:NamedIndividual ; ro:code "s129a" .
+ro_sym:s129b a ro:Symbool, owl:NamedIndividual ; ro:code "s129b" .
+ro_sym:s129c a ro:Symbool, owl:NamedIndividual ; ro:code "s129c" .
+ro_sym:s129d a ro:Symbool, owl:NamedIndividual ; ro:code "s129d" .
+ro_sym:s129e a ro:Symbool, owl:NamedIndividual ; ro:code "s129e" .
+ro_sym:s129f a ro:Symbool, owl:NamedIndividual ; ro:code "s129f" .
+ro_sym:s129g a ro:Symbool, owl:NamedIndividual ; ro:code "s129g" .
+ro_sym:s129h a ro:Symbool, owl:NamedIndividual ; ro:code "s129h" .
+ro_sym:s129i a ro:Symbool, owl:NamedIndividual ; ro:code "s129i" .
+ro_sym:s129j a ro:Symbool, owl:NamedIndividual ; ro:code "s129j" .
+ro_sym:s129k a ro:Symbool, owl:NamedIndividual ; ro:code "s129k" .
+ro_sym:s129l a ro:Symbool, owl:NamedIndividual ; ro:code "s129l" .
+ro_sym:s129m a ro:Symbool, owl:NamedIndividual ; ro:code "s129m" .
+ro_sym:s129n a ro:Symbool, owl:NamedIndividual ; ro:code "s129n" .
+ro_sym:s129o a ro:Symbool, owl:NamedIndividual ; ro:code "s129o" .
+ro_sym:s129p a ro:Symbool, owl:NamedIndividual ; ro:code "s129p" .
+ro_sym:s129q a ro:Symbool, owl:NamedIndividual ; ro:code "s129q" .
+ro_sym:s129r a ro:Symbool, owl:NamedIndividual ; ro:code "s129r" .
+ro_sym:s129s a ro:Symbool, owl:NamedIndividual ; ro:code "s129s" .
+ro_sym:s129t a ro:Symbool, owl:NamedIndividual ; ro:code "s129t" .
+ro_sym:s129u a ro:Symbool, owl:NamedIndividual ; ro:code "s129u" .
+ro_sym:s129v a ro:Symbool, owl:NamedIndividual ; ro:code "s129v" .
+ro_sym:s129w a ro:Symbool, owl:NamedIndividual ; ro:code "s129w" .
+ro_sym:s129x a ro:Symbool, owl:NamedIndividual ; ro:code "s129x" .
+ro_sym:s129y a ro:Symbool, owl:NamedIndividual ; ro:code "s129y" .
+ro_sym:s129z a ro:Symbool, owl:NamedIndividual ; ro:code "s129z" .
+ro_sym:s129aa a ro:Symbool, owl:NamedIndividual ; ro:code "s129aa" .
+ro_sym:s129ab a ro:Symbool, owl:NamedIndividual ; ro:code "s129ab" .
+ro_sym:s130a a ro:Symbool, owl:NamedIndividual ; ro:code "s130a" .
+ro_sym:s130b a ro:Symbool, owl:NamedIndividual ; ro:code "s130b" .
+ro_sym:s130c a ro:Symbool, owl:NamedIndividual ; ro:code "s130c" .
+ro_sym:s130d a ro:Symbool, owl:NamedIndividual ; ro:code "s130d" .
+ro_sym:s130e a ro:Symbool, owl:NamedIndividual ; ro:code "s130e" .
+ro_sym:s130f a ro:Symbool, owl:NamedIndividual ; ro:code "s130f" .
+ro_sym:s130g a ro:Symbool, owl:NamedIndividual ; ro:code "s130g" .
+ro_sym:s130h a ro:Symbool, owl:NamedIndividual ; ro:code "s130h" .
+ro_sym:s130i a ro:Symbool, owl:NamedIndividual ; ro:code "s130i" .
+ro_sym:s130j a ro:Symbool, owl:NamedIndividual ; ro:code "s130j" .
+ro_sym:s130k a ro:Symbool, owl:NamedIndividual ; ro:code "s130k" .
+ro_sym:s130l a ro:Symbool, owl:NamedIndividual ; ro:code "s130l" .
+ro_sym:s130m a ro:Symbool, owl:NamedIndividual ; ro:code "s130m" .
+ro_sym:s130n a ro:Symbool, owl:NamedIndividual ; ro:code "s130n" .
+ro_sym:s130o a ro:Symbool, owl:NamedIndividual ; ro:code "s130o" .
+ro_sym:s130p a ro:Symbool, owl:NamedIndividual ; ro:code "s130p" .
+ro_sym:s130q a ro:Symbool, owl:NamedIndividual ; ro:code "s130q" .
+ro_sym:s130r a ro:Symbool, owl:NamedIndividual ; ro:code "s130r" .
+ro_sym:s130s a ro:Symbool, owl:NamedIndividual ; ro:code "s130s" .
+ro_sym:s130t a ro:Symbool, owl:NamedIndividual ; ro:code "s130t" .
+ro_sym:s130u a ro:Symbool, owl:NamedIndividual ; ro:code "s130u" .
+ro_sym:s130v a ro:Symbool, owl:NamedIndividual ; ro:code "s130v" .
+ro_sym:s130w a ro:Symbool, owl:NamedIndividual ; ro:code "s130w" .

--- a/Models/common/shapes.ttl
+++ b/Models/common/shapes.ttl
@@ -173,3 +173,105 @@ ro_str:prefixes #should we store this here?
       sh:prefix "nen3610" ;
     ] ;
 .
+
+ro_str:RuimtelijkPlanOfBesluit_SV
+  rdf:type sh:NodeShape ;
+  sh:in (
+    ro:Structuurvisie
+    ) ;
+.
+
+#################################################################
+#    Symbool
+#################################################################
+
+ro_str:Symbool a sh:NodeShape ;
+  sh:targetClass ro:Symbool ;
+  sh:property
+    ro_str:Symbool_code ,
+    ro_str:Symbool_positie ;
+.
+
+ro_str:Symbool_code a sh:PropertyShape;
+  sh:path ro:code ;
+  sh:mincount 1 ;
+  sh:maxCount 1 ;
+  sh:nodeKind sh:Literal ;
+  sh:datatype xsd:String ;
+.
+
+ro_str:Symbool_positie a sh:PropertyShape ;
+  sh:path ro:positie ;
+  sh:class sh:Labelpositie ;
+  sh:minCount 1
+.
+
+#################################################################
+#    cartografie
+#################################################################
+
+ro_str:Verbeeldingskaart a sh:NodeShape ;
+  sh:targetClass ro:Verbeeldingskaart ;
+  sh:property
+    ro_str:Verbeeldingskaart_kaartnaam ,
+    ro_str:Verbeeldingskaart_kaartnummer ;
+.
+
+ro_str:Verbeeldingskaart_kaartnaam a sh:PropertyShape ;
+  sh:path rdfs:label ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:datatype xsd:string ;
+.
+
+ro_str:Verbeeldingskaart_kaartnummer a sh:PropertyShape ;
+  sh:path ro:kaartnummer ;
+  sh:minCount 1 ;
+  sh:maxCount 1 ;
+  sh:datatype xsd:string ;
+.
+
+# Because the symbol is specific to the use of a Verbeeldingskaart,
+# we require the reification of the statement that expresses this usage.
+# To that statement we add the symbol as an annotation.
+ro_str:Verbeeldingskaartsymbool a sh:NodeShape ;
+  sh:targetNode ro:isCartografischOnderdeelVan ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:predicate ] ;
+    sh:node ro_str:CartografieSymboolannotatie ;
+  ]
+.
+
+ro_str:CartografieSymboolannotatie a sh:NodeShape ;
+  sh:property
+    [
+      sh:path rdf:subject ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:or (
+        [
+          sh:nodeKind sh:IRI ;
+        ]
+        [
+          sh:nodeKind sh:BlankNode ;
+        ]
+      )
+    ] ,
+    [
+      sh:path rdf:predicate ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:nodeKind sh:IRI ;
+    ] ,
+    [
+      sh:path rdf:object ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+    ] ,
+    [
+      sh:path ro:symbool ;
+      sh:maxCount 1 ;
+      sh:nodeKind sh:IRI ;
+      sh:class ro:Symbool ;
+    ] ;
+.

--- a/Models/common/verwijzing/model.ttl
+++ b/Models/common/verwijzing/model.ttl
@@ -190,37 +190,7 @@ ro:illustratieNaam a owl:AnnotationProperty ;
 #  rdfs:subPropertyOf ro:illustratie ;
 #.
 
-#ro:illustratieverwijzing a owl:Class ;
-#  rdfs:label "illustratieverwijzing"@nl ;
-#.
-
-#################################################################
-#    Cartografie
-#################################################################
-
-ro:cartografie a owl:ObjectProperty ;
-  rdfs:label "cartografie"@nl ;
-  rdfs:isDefinedBy :ro
-.
-
-ro:kaartNaam a owl:AnnotationProperty ;
-  rdfs:label "kaart naam"@nl ;
-  rdfs:isDefinedBy :ro
-.
-
-ro:kaartNummer a owl:DatatypeProperty ;
-  rdfs:label "kaart nummer"@nl ;
-  rdfs:isDefinedBy :ro
-.
-
-ro:symboolCode a owl:DatatypeProperty ;
-  rdfs:label "symbool code"@nl ;
-  rdfs:isDefinedBy :ro
-.
-
-#################################################################
-#    Extern plan
-#################################################################
+### extern plan
 
 ro:externPlan a owl:ObjectProperty ;
   rdfs:label "extern plan"@nl ;

--- a/Models/common/verwijzing/shapes.ttl
+++ b/Models/common/verwijzing/shapes.ttl
@@ -108,38 +108,6 @@ ro_str:Illustratie_IllustratieNaam a sh:NodeShape ; #can I treat a nodeshape as 
 .
 
 #################################################################
-#    Cartografie
-#################################################################
-
-ro_str:cartografieInfo a sh:NodeShape ;     #[0...*] cardinality of properties
-  sh:property
-    ro_str:cartografieInfo_kaartNaam ,
-    ro_str:cartografieInfo_kaartNummer ,
-    ro_str:cartografieInfo_symboolCode
-.
-
-ro_str:cartografieInfo_kaartNaam a sh:PropertyShape ;
-  sh:path ro:kaartNaam ;
-  sh:minCount 1 ;
-  sh:maxCount 1 ;
-  sh:datatype xsd:string
-.
-
-ro_str:cartografieInfo_kaartNummer a sh:PropertyShape ;
-  sh:path ro:kaartNummer ;
-  sh:minCount 1 ;
-  sh:maxCount 1 ;
-  sh:datatype xsd:string
-.
-
-ro_str:cartografieInfo_symboolCode a sh:PropertyShape ;
-  sh:path ro:symboolCode ;
-  sh:maxCount 1 ;
-  sh:datatype xsd:string
-.
-
-
-#################################################################
 #    Extern plan
 #################################################################
 


### PR DESCRIPTION
- Replaced currenct `ro:cartografieInfo` with `ro:isCartografischOnderdeelVan` pointing to a class `ro:Verbeeldingskaart`. This in order to capture the semantics better. Basically the current cartografieInfo construct in IMRO is used to categorize certain plan objects within a thematic map.
- Moved symbols and cartorgafie constructs to main common section as it has nothing to do with verwijzing.
- Fixed small URI problem in Models/common/begrip.ttl